### PR TITLE
Moved date validation up

### DIFF
--- a/src/offkai_bot/data/event.py
+++ b/src/offkai_bot/data/event.py
@@ -306,8 +306,8 @@ def add_event(
     """Creates an Event object and adds it to the in-memory cache."""
 
     # Step 1: Validation
-    validate_event_datetime(event_datetime)
-    validate_event_deadline(event_datetime, event_deadline)
+    # validate_event_datetime(event_datetime)
+    # validate_event_deadline(event_datetime, event_deadline)
 
     # Step 2: Data Object Creation
     new_event = Event(

--- a/src/offkai_bot/main.py
+++ b/src/offkai_bot/main.py
@@ -50,6 +50,8 @@ from .event_actions import (
 from .util import (
     parse_drinks,
     parse_event_datetime,
+    validate_event_datetime,
+    validate_event_deadline,
     validate_interaction_context,
 )
 
@@ -170,6 +172,8 @@ async def create_offkai(
 
     # 3. Context Validation
     validate_interaction_context(interaction)
+    validate_event_datetime(event_datetime)
+    validate_event_deadline(event_datetime, event_deadline)
 
     # --- Discord Interaction Block ---
     try:

--- a/tests/commands/test_create_offkai.py
+++ b/tests/commands/test_create_offkai.py
@@ -421,7 +421,7 @@ async def test_create_offkai_thread_creation_fails(
     # Arrange
     event_name = "Thread Fail Test"
     mock_get_event.side_effect = EventNotFoundError(event_name)
-    mock_parse_dt.return_value = datetime.now()
+    mock_parse_dt.return_value = datetime.strptime("3000-01-01 10:00", r"%Y-%m-%d %H:%M").replace(tzinfo=JST)
     mock_parse_drinks.return_value = []
     mock_validate_ctx.return_value = None  # Assume context is valid
     # Simulate discord API error during thread creation


### PR DESCRIPTION
Moved date validation from `add_event()` to `create_offkai()` so thread is not created if dates are invalid.