### PR TITLE
Allow bot to pin the offkai announcement by himself

### DIFF
--- a/src/offkai_bot/errors.py
+++ b/src/offkai_bot/errors.py
@@ -245,7 +245,7 @@ class PinPermissionError(BotCommandError):
 
     log_level = logging.WARNING
 
-    def __init__(self, channel: Thread, original_exception: Forbidden):
+    def __init__(self, channel, original_exception: Forbidden):
         self.channel = channel
         self.original_exception = original_exception
         super().__init__(

--- a/src/offkai_bot/main.py
+++ b/src/offkai_bot/main.py
@@ -224,6 +224,16 @@ async def create_offkai(
     announce_text += f"Join the discussion and RSVP here: {thread.mention}"
     await interaction.response.send_message(announce_text)
 
+    message = await interaction.original_response()
+    try:
+        await message.pin()
+    except discord.Forbidden as e:
+        if message:
+            _log.warning("Failed to pin message: Missing 'Pins' permission.")
+            raise PinPermissionError(message.channel, e) from e
+    except discord.HTTPException as e:
+        _log.error(f"Failed to pin message due to HTTP error: {e}")
+
 
 @client.tree.command(
     name="modify_offkai",


### PR DESCRIPTION
Allows the offkai-bot to pin the message it create in the main live channel
instead of having a mod manually pin the message