### PR TITLE
Capture nicknames during registration

### DIFF
--- a/src/offkai_bot/cogs/events.py
+++ b/src/offkai_bot/cogs/events.py
@@ -373,13 +373,17 @@ class EventsCog(commands.Cog):
         description="Gets the list of attendees and count for an event.",
     )
     @app_commands.describe(
-        event_name="The name of the event.", sort="Whether to sort the attendance list. (default: False)"
+        event_name="The name of the event.",
+        sort="Whether to sort the attendance list. (default: False)",
+        nicknames="Whether to show display names alongside usernames. (default: False)",
     )
     @app_commands.checks.has_role("Offkai Organizer")
     @log_command_usage
-    async def attendance(self, interaction: discord.Interaction, event_name: str, sort: bool = False):
+    async def attendance(
+        self, interaction: discord.Interaction, event_name: str, sort: bool = False, nicknames: bool = False
+    ):
         get_event(event_name)
-        total_count, attendee_list = calculate_attendance(event_name)
+        total_count, attendee_list = calculate_attendance(event_name, nicknames=nicknames)
         if sort:
             attendee_list.sort(key=str.lower)
 

--- a/src/offkai_bot/interactions.py
+++ b/src/offkai_bot/interactions.py
@@ -138,6 +138,7 @@ async def promote_waitlist_batch(event: Event, client: discord.Client) -> list[i
             timestamp=promoted_entry.timestamp,
             drinks=promoted_entry.drinks,
             extras_names=promoted_entry.extras_names,
+            display_name=promoted_entry.display_name,
         )
         add_response(event.event_name, promoted_response)
         promoted_count += 1
@@ -486,6 +487,7 @@ class GatheringModal(ui.Modal):
                     timestamp=datetime.now(UTC),
                     drinks=selected_drinks,
                     extras_names=extra_people_names,
+                    display_name=interaction.user.display_name,
                 )
 
                 add_to_waitlist(self.event.event_name, new_entry)
@@ -517,6 +519,7 @@ class GatheringModal(ui.Modal):
                     timestamp=datetime.now(UTC),
                     drinks=selected_drinks,
                     extras_names=extra_people_names,
+                    display_name=interaction.user.display_name,
                 )
 
                 # Add to waitlist
@@ -537,6 +540,7 @@ class GatheringModal(ui.Modal):
                     timestamp=datetime.now(UTC),
                     drinks=selected_drinks,
                     extras_names=extra_people_names,
+                    display_name=interaction.user.display_name,
                 )
 
                 add_response(self.event.event_name, new_response)

--- a/tests/commands/test_capacity_waitlist.py
+++ b/tests/commands/test_capacity_waitlist.py
@@ -6,6 +6,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import discord
 import pytest
 from discord.ext import commands
+
 from offkai_bot.cogs.events import EventsCog
 from offkai_bot.data import response as response_data
 from offkai_bot.data.event import Event

--- a/tests/commands/test_closed_attendance_count.py
+++ b/tests/commands/test_closed_attendance_count.py
@@ -5,6 +5,7 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from discord.ext import commands
+
 from offkai_bot.cogs.events import EventsCog
 from offkai_bot.data import event as event_data
 from offkai_bot.data import response as response_data


### PR DESCRIPTION
Added nicknames for offkai registration.

This helps when printing the attendance to also see the nicknames of the registered people instead of the usernames.
