### PR TITLE
Fix autocomplete for promote events

### DIFF
--- a/src/offkai_bot/cogs/events.py
+++ b/src/offkai_bot/cogs/events.py
@@ -642,7 +642,7 @@ class EventsCog(commands.Cog):
     close_offkai.autocomplete("event_name")(offkai_autocomplete_active)
     broadcast.autocomplete("event_name")(offkai_autocomplete_active)
     delete_response.autocomplete("event_name")(offkai_autocomplete_active)
-    promote.autocomplete("event_name")(offkai_autocomplete_active)
+    promote.autocomplete("event_name")(offkai_autocomplete_all_non_archived)
     promote.autocomplete("username")(waitlist_user_autocomplete)
     attendance.autocomplete("event_name")(offkai_autocomplete_all_non_archived)
     waitlist.autocomplete("event_name")(offkai_autocomplete_all_non_archived)

--- a/tests/test_event_autocomplete.py
+++ b/tests/test_event_autocomplete.py
@@ -252,6 +252,12 @@ async def test_offkai_autocomplete_all_non_archived(mock_base_autocomplete, mock
     mock_base_autocomplete.assert_awaited_once_with(mock_interaction, current_str, open_status=None)
 
 
+async def test_promote_event_autocomplete_includes_all_non_archived_events():
+    """Test promote can find closed, non-archived events with waitlists."""
+    autocomplete = EventsCog.promote._params["event_name"].autocomplete
+    assert autocomplete is EventsCog.offkai_autocomplete_all_non_archived
+
+
 # --- Tests for waitlist_user_autocomplete ---
 
 


### PR DESCRIPTION
Fixes issues with promote command only working on open events
so closed events but not archieved can't be found by the promote command
this fix fixes it