### PR TITLE
Fix attendance and waitlist sorting to bundle extras after main users

### DIFF
--- a/src/offkai_bot/cogs/events.py
+++ b/src/offkai_bot/cogs/events.py
@@ -534,9 +534,7 @@ class EventsCog(commands.Cog):
         drinks: bool = False,
     ):
         get_event(event_name)
-        total_count, attendee_list = calculate_attendance(event_name, nicknames=nicknames, drinks=drinks)
-        if sort:
-            attendee_list.sort(key=str.lower)
+        total_count, attendee_list = calculate_attendance(event_name, nicknames=nicknames, drinks=drinks, sort=sort)
 
         output = _format_attendance_output(event_name, total_count, attendee_list)
 
@@ -584,9 +582,7 @@ class EventsCog(commands.Cog):
         self, interaction: discord.Interaction, event_name: str, sort: bool = False, nicknames: bool = False
     ):
         get_event(event_name)
-        total_count, waitlisted_list = calculate_waitlist(event_name, nicknames=nicknames)
-        if sort:
-            waitlisted_list.sort(key=str.lower)
+        total_count, waitlisted_list = calculate_waitlist(event_name, nicknames=nicknames, sort=sort)
 
         output = f"**Waitlist for {event_name}**\n\n"
         output += f"Total Waitlisted: **{total_count}**\n\n"

--- a/src/offkai_bot/data/response.py
+++ b/src/offkai_bot/data/response.py
@@ -525,7 +525,9 @@ def promote_specific_from_waitlist(event_name: str, user_id: int) -> WaitlistEnt
     raise ResponseNotFoundError(event_name, user_id)
 
 
-def calculate_attendance(event_name: str, *, nicknames: bool = False, drinks: bool = False) -> tuple[int, list[str]]:
+def calculate_attendance(
+    event_name: str, *, nicknames: bool = False, drinks: bool = False, sort: bool = False
+) -> tuple[int, list[str]]:
     """
     Calculates the total attendance count and generates a list of attendee names
     (including extras) for a given event.
@@ -534,6 +536,7 @@ def calculate_attendance(event_name: str, *, nicknames: bool = False, drinks: bo
         event_name: The name of the event.
         nicknames: If True, show display names alongside usernames when they differ.
         drinks: If True, append each attendee's drink choice.
+        sort: If True, sort based on the main user and bundle extras after them.
 
     Returns:
         A tuple containing:
@@ -546,6 +549,9 @@ def calculate_attendance(event_name: str, *, nicknames: bool = False, drinks: bo
     responses = get_responses(event_name)
     if not responses:
         raise NoResponsesFoundError(event_name)
+
+    if sort:
+        responses = sorted(responses, key=lambda r: r.username.lower())
 
     attendee_names = []
     total_count = 0
@@ -562,7 +568,9 @@ def calculate_attendance(event_name: str, *, nicknames: bool = False, drinks: bo
 
         # Add extra people
         for i in range(response.extra_people):
-            name = response.extras_names[i] if i < len(response.extras_names) else " "
+            raw_name = response.extras_names[i] if i < len(response.extras_names) else ""
+            stripped_name = raw_name.strip() if isinstance(raw_name, str) else ""
+            name = stripped_name or " "
             name += f" ({response.username} +{i + 1})"
             if drinks:
                 drink_index = i + 1
@@ -575,7 +583,7 @@ def calculate_attendance(event_name: str, *, nicknames: bool = False, drinks: bo
     return total_count, attendee_names
 
 
-def calculate_waitlist(event_name: str, *, nicknames: bool = False) -> tuple[int, list[str]]:
+def calculate_waitlist(event_name: str, *, nicknames: bool = False, sort: bool = False) -> tuple[int, list[str]]:
     """
     Calculates the total waitlist count and generates a list of waitlisted names
     (including extras) for a given event.
@@ -583,6 +591,7 @@ def calculate_waitlist(event_name: str, *, nicknames: bool = False) -> tuple[int
     Args:
         event_name: The name of the event.
         nicknames: If True, show display names alongside usernames when they differ.
+        sort: If True, sort based on the main user and bundle extras after them.
 
     Returns:
         A tuple containing:
@@ -596,6 +605,9 @@ def calculate_waitlist(event_name: str, *, nicknames: bool = False) -> tuple[int
     if not entries:
         raise NoWaitlistEntriesFoundError(event_name)
 
+    if sort:
+        entries = sorted(entries, key=lambda e: e.username.lower())
+
     waitlisted_names = []
     total_count = 0
     for entry in entries:
@@ -606,7 +618,9 @@ def calculate_waitlist(event_name: str, *, nicknames: bool = False) -> tuple[int
         total_count += 1
 
         for i in range(entry.extra_people):
-            name = entry.extras_names[i] if i < len(entry.extras_names) else " "
+            raw_name = entry.extras_names[i] if i < len(entry.extras_names) else ""
+            stripped_name = raw_name.strip() if isinstance(raw_name, str) else ""
+            name = stripped_name or " "
             name += f" ({entry.username} +{i + 1})"
             waitlisted_names.append(name)
             total_count += 1

--- a/src/offkai_bot/interactions.py
+++ b/src/offkai_bot/interactions.py
@@ -342,7 +342,7 @@ class GatheringModal(ui.Modal):
         if extras == "":
             names = []
         else:
-            names = extras.split(",")
+            names = [name.strip() for name in extras.split(",")]
             _log.debug("len(names)=%s, num_extra=%s", len(names), num_extra)
             if len(names) != num_extra:
                 raise ValidationError(

--- a/tests/commands/test_attendance.py
+++ b/tests/commands/test_attendance.py
@@ -96,7 +96,7 @@ async def test_attendance_success(
     # 1. Check get_event call
     mock_get_event.assert_called_once_with(event_name_target)
     # 2. Check calculate_attendance call
-    mock_calculate_attendance.assert_called_once_with(event_name_target, nicknames=False, drinks=False)
+    mock_calculate_attendance.assert_called_once_with(event_name_target, nicknames=False, drinks=False, sort=False)
     # 3. Check final interaction response with correct formatting
     expected_output = (
         f"**Attendance for {event_name_target}**\n\n"
@@ -143,7 +143,7 @@ async def test_attendance_with_drinks(
 
     # Assert
     mock_get_event.assert_called_once_with(event_name_target)
-    mock_calculate_attendance.assert_called_once_with(event_name_target, nicknames=False, drinks=True)
+    mock_calculate_attendance.assert_called_once_with(event_name_target, nicknames=False, drinks=True, sort=False)
     expected_output = (
         f"**Attendance for {event_name_target}**\n\n"
         "Total Attendees: **3**\n\n"
@@ -174,7 +174,7 @@ async def test_attendance_sort_success(
 
     # Mock the data layer function returning attendance data
     mock_total_count = 5
-    mock_attendee_list = ["UserC", "UserC +1", "UserA", "UserB", "UserB +1"]
+    mock_attendee_list = ["UserA", "UserB", "UserB +1", "UserC", "UserC +1"]
     mock_calculate_attendance.return_value = (mock_total_count, mock_attendee_list)
 
     # Act
@@ -189,7 +189,7 @@ async def test_attendance_sort_success(
     # 1. Check get_event call
     mock_get_event.assert_called_once_with(event_name_target)
     # 2. Check calculate_attendance call
-    mock_calculate_attendance.assert_called_once_with(event_name_target, nicknames=False, drinks=False)
+    mock_calculate_attendance.assert_called_once_with(event_name_target, nicknames=False, drinks=False, sort=True)
     # 3. Check final interaction response with correct formatting
     expected_output = (
         f"**Attendance for {event_name_target}**\n\n"
@@ -246,7 +246,7 @@ async def test_attendance_success_truncation(
 
     # Assert
     mock_get_event.assert_called_once_with(event_name_target)
-    mock_calculate_attendance.assert_called_once_with(event_name_target, nicknames=False, drinks=False)
+    mock_calculate_attendance.assert_called_once_with(event_name_target, nicknames=False, drinks=False, sort=False)
     mock_interaction.response.send_message.assert_awaited_once_with(expected_truncated_output, ephemeral=True)
 
 
@@ -287,7 +287,7 @@ async def test_attendance_over_100_sends_file_by_dm(
 
     # Assert
     mock_get_event.assert_called_once_with(event_name_target)
-    mock_calculate_attendance.assert_called_once_with(event_name_target, nicknames=False, drinks=False)
+    mock_calculate_attendance.assert_called_once_with(event_name_target, nicknames=False, drinks=False, sort=False)
     mock_discord_file.assert_called_once()
     assert mock_discord_file.call_args.kwargs["filename"] == "attendance_Summer_Bash.txt"
     assert mock_discord_file.call_args.kwargs["fp"].getvalue() == expected_output.encode("utf-8")
@@ -340,7 +340,7 @@ async def test_attendance_over_100_with_drinks_sends_file_by_dm(
 
     # Assert
     mock_get_event.assert_called_once_with(event_name_target)
-    mock_calculate_attendance.assert_called_once_with(event_name_target, nicknames=False, drinks=True)
+    mock_calculate_attendance.assert_called_once_with(event_name_target, nicknames=False, drinks=True, sort=False)
     mock_discord_file.assert_called_once()
     assert mock_discord_file.call_args.kwargs["filename"] == "attendance_Summer_Bash.txt"
     assert mock_discord_file.call_args.kwargs["fp"].getvalue() == expected_output.encode("utf-8")
@@ -390,7 +390,7 @@ async def test_attendance_over_100_falls_back_to_ephemeral_file_when_dm_fails(
 
     # Assert
     mock_get_event.assert_called_once_with(event_name_target)
-    mock_calculate_attendance.assert_called_once_with(event_name_target, nicknames=False, drinks=False)
+    mock_calculate_attendance.assert_called_once_with(event_name_target, nicknames=False, drinks=False, sort=False)
     assert mock_discord_file.call_count == 2
     mock_interaction.user.send.assert_awaited_once_with(
         f"Attendance for **{event_name_target}** is attached as a text file.",
@@ -462,7 +462,7 @@ async def test_attendance_no_responses_found(
 
     # Assert calls up to calculate_attendance
     mock_get_event.assert_called_once_with(event_name_target)
-    mock_calculate_attendance.assert_called_once_with(event_name_target, nicknames=False, drinks=False)
+    mock_calculate_attendance.assert_called_once_with(event_name_target, nicknames=False, drinks=False, sort=False)
 
     # Assert subsequent steps were NOT called
     mock_interaction.response.send_message.assert_not_awaited()
@@ -496,7 +496,7 @@ async def test_attendance_with_nicknames(
 
     # Assert
     mock_get_event.assert_called_once_with(event_name_target)
-    mock_calculate_attendance.assert_called_once_with(event_name_target, nicknames=True, drinks=False)
+    mock_calculate_attendance.assert_called_once_with(event_name_target, nicknames=True, drinks=False, sort=False)
 
     expected_output = f"**Attendance for {event_name_target}**\n\nTotal Attendees: **2**\n\n1. foo (goo)\n2. bar"
     mock_interaction.response.send_message.assert_awaited_once_with(expected_output, ephemeral=True)

--- a/tests/commands/test_waitlist.py
+++ b/tests/commands/test_waitlist.py
@@ -86,7 +86,7 @@ async def test_waitlist_success(
     )
 
     mock_get_event.assert_called_once_with(event_name_target)
-    mock_calculate_waitlist.assert_called_once_with(event_name_target, nicknames=False)
+    mock_calculate_waitlist.assert_called_once_with(event_name_target, nicknames=False, sort=False)
 
     expected_output = (
         f"**Waitlist for {event_name_target}**\n\n"
@@ -116,7 +116,7 @@ async def test_waitlist_sort_success(
     mock_get_event.return_value = mock_event_obj
 
     mock_total_count = 3
-    mock_waitlisted_list = ["UserC", "UserA", "UserB"]
+    mock_waitlisted_list = ["UserA", "UserB", "UserC"]
     mock_calculate_waitlist.return_value = (mock_total_count, mock_waitlisted_list)
 
     await EventsCog.waitlist.callback(
@@ -127,7 +127,7 @@ async def test_waitlist_sort_success(
     )
 
     mock_get_event.assert_called_once_with(event_name_target)
-    mock_calculate_waitlist.assert_called_once_with(event_name_target, nicknames=False)
+    mock_calculate_waitlist.assert_called_once_with(event_name_target, nicknames=False, sort=True)
 
     expected_output = (
         f"**Waitlist for {event_name_target}**\n\n"
@@ -175,7 +175,7 @@ async def test_waitlist_success_truncation(
     )
 
     mock_get_event.assert_called_once_with(event_name_target)
-    mock_calculate_waitlist.assert_called_once_with(event_name_target, nicknames=False)
+    mock_calculate_waitlist.assert_called_once_with(event_name_target, nicknames=False, sort=False)
     mock_interaction.response.send_message.assert_awaited_once_with(expected_truncated_output, ephemeral=True)
 
 
@@ -231,7 +231,7 @@ async def test_waitlist_no_entries_found(
         )
 
     mock_get_event.assert_called_once_with(event_name_target)
-    mock_calculate_waitlist.assert_called_once_with(event_name_target, nicknames=False)
+    mock_calculate_waitlist.assert_called_once_with(event_name_target, nicknames=False, sort=False)
     mock_interaction.response.send_message.assert_not_awaited()
 
 
@@ -260,7 +260,7 @@ async def test_waitlist_with_nicknames(
     )
 
     mock_get_event.assert_called_once_with(event_name_target)
-    mock_calculate_waitlist.assert_called_once_with(event_name_target, nicknames=True)
+    mock_calculate_waitlist.assert_called_once_with(event_name_target, nicknames=True, sort=False)
 
     expected_output = f"**Waitlist for {event_name_target}**\n\nTotal Waitlisted: **2**\n\n1. foo (goo)\n2. bar"
     mock_interaction.response.send_message.assert_awaited_once_with(expected_output, ephemeral=True)

--- a/tests/data/test_response.py
+++ b/tests/data/test_response.py
@@ -1436,3 +1436,110 @@ def test_calculate_waitlist_empty(mock_paths):
         pytest.raises(NoWaitlistEntriesFoundError),
     ):
         response_data.calculate_waitlist("Event W")
+
+
+# --- Tests for sorting and extras bundling ---
+
+
+def test_calculate_attendance_sorting_bundles_extras_after_main_user(mock_paths):
+    """Test that calculate_attendance with sort=True sorts by main user and bundles extras immediately after."""
+    resp_b = Response(
+        user_id=222,
+        username="B",
+        extra_people=2,
+        behavior_confirmed=True,
+        arrival_confirmed=True,
+        event_name="Event X",
+        timestamp=datetime.now(UTC),
+        drinks=[],
+        extras_names=[" AA", "AB "],  # spaces to verify stripping
+    )
+    resp_a = Response(
+        user_id=111,
+        username="A",
+        extra_people=0,
+        behavior_confirmed=True,
+        arrival_confirmed=True,
+        event_name="Event X",
+        timestamp=datetime.now(UTC),
+        drinks=[],
+        extras_names=[],
+    )
+    resp_c = Response(
+        user_id=333,
+        username="C",
+        extra_people=0,
+        behavior_confirmed=True,
+        arrival_confirmed=True,
+        event_name="Event X",
+        timestamp=datetime.now(UTC),
+        drinks=[],
+        extras_names=[],
+    )
+
+    # Place them in non-sorted order in the cache
+    response_data.RESPONSE_DATA_CACHE = {"Event X": make_event_data([resp_b, resp_a, resp_c])}
+
+    with patch("offkai_bot.data.response.load_responses", return_value=response_data.RESPONSE_DATA_CACHE):
+        total_count, attendee_names = response_data.calculate_attendance("Event X", sort=True)
+
+    assert total_count == 5
+    assert attendee_names == [
+        "A",
+        "B",
+        "AA (B +1)",
+        "AB (B +2)",
+        "C",
+    ]
+
+
+def test_calculate_waitlist_sorting_bundles_extras_after_main_user(mock_paths):
+    """Test that calculate_waitlist with sort=True sorts by main user and bundles extras immediately after."""
+    entry_b = WaitlistEntry(
+        user_id=222,
+        username="B",
+        extra_people=2,
+        behavior_confirmed=True,
+        arrival_confirmed=True,
+        event_name="Event X",
+        timestamp=datetime.now(UTC),
+        drinks=[],
+        extras_names=[" AA", "AB "],  # spaces to verify stripping
+    )
+    entry_a = WaitlistEntry(
+        user_id=111,
+        username="A",
+        extra_people=0,
+        behavior_confirmed=True,
+        arrival_confirmed=True,
+        event_name="Event X",
+        timestamp=datetime.now(UTC),
+        drinks=[],
+        extras_names=[],
+    )
+    entry_c = WaitlistEntry(
+        user_id=333,
+        username="C",
+        extra_people=0,
+        behavior_confirmed=True,
+        arrival_confirmed=True,
+        event_name="Event X",
+        timestamp=datetime.now(UTC),
+        drinks=[],
+        extras_names=[],
+    )
+
+    # Place them in non-sorted order in the cache
+    response_data.RESPONSE_DATA_CACHE = {"Event X": make_event_data(waitlist=[entry_b, entry_a, entry_c])}
+
+    with patch("offkai_bot.data.response.load_responses", return_value=response_data.RESPONSE_DATA_CACHE):
+        total_count, waitlisted_names = response_data.calculate_waitlist("Event X", sort=True)
+
+    assert total_count == 5
+    assert waitlisted_names == [
+        "A",
+        "B",
+        "AA (B +1)",
+        "AB (B +2)",
+        "C",
+    ]


### PR DESCRIPTION
## Description

  This PR resolves an issue with the  /attendance  (and  /waitlist ) commands when using  sort=True . Currently,
  sorting alphabetically on the flattened list of attendees separates extra guests from the main user who registered
  them, and places extras with leading whitespaces at the very top of the list.

  ### Proposed Solution

  1. Sorted Data Layer Retrieval: Added a  sort  argument to  calculate_attendance  and  calculate_waitlist . When   
  sort=True , main users are sorted alphabetically by  username  case-insensitively, and their extras are compiled
  immediately after them. This preserves group bundling (e.g.  A, B, B's Extra 1, B's Extra 2, C ).
  2. Whitespace Stripping for Extra Names:
      • Cleaned extra names when splitting them on registration modals to prevent double spaces.
      • Robustly stripped extra names from existing stored database records during output generation.
  3. Decoupled Cog Logic: Delegate sorting entirely to the data layer inside  events.py  rather than sorting the
  flattened attendee strings inside the cog command callback.

  ## Tests & Verification

  • Added dedicated unit tests in  tests/data/test_response.py  verifying sorting and extra bundling behavior.
  • Updated mocked command tests in  tests/commands/test_attendance.py  and  tests/commands/test_waitlist.py .
  • Ran  pytest  locally; all 458 tests pass successfully.