### PR TITLE
feat: validate extras names to prevent empty or whitespace-only guest names

### DIFF
--- a/src/offkai_bot/interactions.py
+++ b/src/offkai_bot/interactions.py
@@ -338,18 +338,28 @@ class GatheringModal(ui.Modal):
         return selected_drinks
 
     def _validate_extra_people_names(self, extras: str, num_extra: int) -> list[str]:
-        names: list[str] = []
-        if extras == "":
-            names = []
-        else:
-            names = [name.strip() for name in extras.split(",")]
-            _log.debug("len(names)=%s, num_extra=%s", len(names), num_extra)
-            if len(names) != num_extra:
-                raise ValidationError(
-                    f"Please provide exactly {num_extra} names "
-                    "(one for each person you are bringing), separated by commas."
-                )
-        return names
+        if num_extra == 0:
+            if extras.strip() != "":
+                raise ValidationError("You specified 0 extra people, so please leave the extras names field empty.")
+            return []
+
+        # If they bring extra people, extras names are required
+        if not extras.strip():
+            raise ValidationError(
+                f"Please provide exactly {num_extra} name(s) "
+                "(one for each person you are bringing), separated by commas."
+            )
+
+        names = [name.strip() for name in extras.split(",")]
+        # Filter out empty names to ensure they don't submit ",,," or similar
+        non_empty_names = [name for name in names if name]
+
+        if len(non_empty_names) != num_extra:
+            raise ValidationError(
+                f"Please provide exactly {num_extra} non-empty name(s) "
+                "(one for each person you are bringing), separated by commas."
+            )
+        return non_empty_names
 
     async def _handle_successful_submission(self, interaction: discord.Interaction, response: Response):
         """Handles actions after a response is successfully added."""

--- a/tests/commands/test_capacity_waitlist.py
+++ b/tests/commands/test_capacity_waitlist.py
@@ -670,6 +670,8 @@ async def test_modal_adds_to_waitlist_when_group_exceeds_capacity(event_with_cap
     modal.arrival_checkbox_input = MagicMock()
     modal.arrival_checkbox_input.value = "Yes"
     modal.drink_choice_input = None
+    modal.extras_names_input = MagicMock()
+    modal.extras_names_input.value = "Guest1"
 
     await modal.on_submit(mock_interaction)
 
@@ -710,6 +712,8 @@ async def test_modal_capacity_exceeded_message_content(event_with_capacity, mock
     modal.arrival_checkbox_input = MagicMock()
     modal.arrival_checkbox_input.value = "Yes"
     modal.drink_choice_input = None
+    modal.extras_names_input = MagicMock()
+    modal.extras_names_input.value = "Guest1"
 
     await modal.on_submit(mock_interaction)
 
@@ -753,6 +757,8 @@ async def test_capacity_reached_message_sent_when_filling_event(event_with_capac
         modal.arrival_checkbox_input = MagicMock()
         modal.arrival_checkbox_input.value = "Yes"
         modal.drink_choice_input = None
+        modal.extras_names_input = MagicMock()
+        modal.extras_names_input.value = "Guest1"
 
         await modal.on_submit(mock_interaction)
 
@@ -854,6 +860,8 @@ async def test_waitlist_capacity_exceeded_dm_contains_extra_charge_warning(
     modal.arrival_checkbox_input = MagicMock()
     modal.arrival_checkbox_input.value = "Yes"
     modal.drink_choice_input = None
+    modal.extras_names_input = MagicMock()
+    modal.extras_names_input.value = "Guest1"
 
     await modal.on_submit(mock_interaction)
 

--- a/tests/test_extras_names_validation.py
+++ b/tests/test_extras_names_validation.py
@@ -7,6 +7,7 @@ import discord
 import pytest
 
 from offkai_bot.data.event import Event
+from offkai_bot.interactions import GatheringModal, ValidationError
 
 # --- Fixtures ---
 
@@ -50,97 +51,105 @@ def sample_event():
 
 
 # --- Tests for _validate_extra_people_names ---
-# Test the validation method directly without creating a modal instance
 
 
-def test_validate_extra_people_names_empty_string_no_extras():
+@pytest.mark.asyncio
+async def test_validate_extra_people_names_empty_string_no_extras(sample_event):
     """Test validation with empty string when no extra people expected."""
-    # Create a temporary modal instance just to call the method
-    # We need to do this in an async context or use a mock
-    # For simplicity, we'll test the logic directly
-    extras = ""
-    num_extra = 0
-
-    names: list[str] = []
-    if extras == "":
-        names = []
-    else:
-        names = extras.split(",")
-        if len(names) != num_extra:
-            pytest.fail("Should not raise error")
-
+    modal = GatheringModal(event=sample_event)
+    names = modal._validate_extra_people_names("", 0)
     assert names == []
 
 
-def test_validate_extra_people_names_correct_count():
-    """Test validation with correct number of names."""
-    extras = "Alice,Bob"
-    num_extra = 2
+@pytest.mark.asyncio
+async def test_validate_extra_people_names_whitespace_no_extras(sample_event):
+    """Test validation with whitespace when no extra people expected."""
+    modal = GatheringModal(event=sample_event)
+    names = modal._validate_extra_people_names("   ", 0)
+    assert names == []
 
-    names = extras.split(",")
-    assert len(names) == num_extra
+
+@pytest.mark.asyncio
+async def test_validate_extra_people_names_non_empty_no_extras(sample_event):
+    """Test validation raises error when names are provided but 0 extras expected."""
+    modal = GatheringModal(event=sample_event)
+    with pytest.raises(ValidationError) as exc_info:
+        modal._validate_extra_people_names("Alice", 0)
+    assert "You specified 0 extra people" in str(exc_info.value)
+
+
+@pytest.mark.asyncio
+async def test_validate_extra_people_names_correct_count(sample_event):
+    """Test validation with correct number of names."""
+    modal = GatheringModal(event=sample_event)
+    names = modal._validate_extra_people_names("Alice,Bob", 2)
     assert names == ["Alice", "Bob"]
 
 
-def test_validate_extra_people_names_single_name():
+@pytest.mark.asyncio
+async def test_validate_extra_people_names_single_name(sample_event):
     """Test validation with single extra person."""
-    extras = "Charlie"
-    num_extra = 1
-
-    names = extras.split(",")
-    assert len(names) == num_extra
+    modal = GatheringModal(event=sample_event)
+    names = modal._validate_extra_people_names("Charlie", 1)
     assert names == ["Charlie"]
 
 
-def test_validate_extra_people_names_with_spaces():
+@pytest.mark.asyncio
+async def test_validate_extra_people_names_with_spaces(sample_event):
     """Test validation with names containing spaces."""
-    extras = "Alice Smith,Bob Jones,Charlie Brown"
-    num_extra = 3
-
-    names = extras.split(",")
-    assert len(names) == num_extra
+    modal = GatheringModal(event=sample_event)
+    names = modal._validate_extra_people_names("Alice Smith, Bob Jones, Charlie Brown", 3)
     assert names == ["Alice Smith", "Bob Jones", "Charlie Brown"]
 
 
-def test_validate_extra_people_names_too_few_names():
+@pytest.mark.asyncio
+async def test_validate_extra_people_names_too_few_names(sample_event):
     """Test validation raises error when too few names provided."""
-    extras = "Alice"
-    num_extra = 2
+    modal = GatheringModal(event=sample_event)
+    with pytest.raises(ValidationError) as exc_info:
+        modal._validate_extra_people_names("Alice", 2)
+    assert "Please provide exactly 2 non-empty name(s)" in str(exc_info.value)
 
-    names = extras.split(",")
-    assert len(names) != num_extra
 
-
-def test_validate_extra_people_names_too_many_names():
+@pytest.mark.asyncio
+async def test_validate_extra_people_names_too_many_names(sample_event):
     """Test validation raises error when too many names provided."""
-    extras = "Alice,Bob,Charlie"
-    num_extra = 2
+    modal = GatheringModal(event=sample_event)
+    with pytest.raises(ValidationError) as exc_info:
+        modal._validate_extra_people_names("Alice,Bob,Charlie", 2)
+    assert "Please provide exactly 2 non-empty name(s)" in str(exc_info.value)
 
-    names = extras.split(",")
-    assert len(names) != num_extra
 
-
-def test_validate_extra_people_names_empty_when_extras_expected():
+@pytest.mark.asyncio
+async def test_validate_extra_people_names_empty_when_extras_expected(sample_event):
     """Test validation with empty string when extras are expected."""
-    extras = ""
-    num_extra = 1
-
-    names = [] if extras == "" else extras.split(",")
-
-    assert len(names) != num_extra
+    modal = GatheringModal(event=sample_event)
+    with pytest.raises(ValidationError) as exc_info:
+        modal._validate_extra_people_names("", 1)
+    assert "Please provide exactly 1 name(s)" in str(exc_info.value)
 
 
-def test_validate_extra_people_names_provided_when_no_extras():
-    """Test validation with names provided when no extras expected."""
-    extras = "Alice"
-    num_extra = 0
+@pytest.mark.asyncio
+async def test_validate_extra_people_names_whitespace_when_extras_expected(sample_event):
+    """Test validation with whitespace when extras are expected."""
+    modal = GatheringModal(event=sample_event)
+    with pytest.raises(ValidationError) as exc_info:
+        modal._validate_extra_people_names("    ", 1)
+    assert "Please provide exactly 1 name(s)" in str(exc_info.value)
 
-    names = extras.split(",")
-    assert len(names) != num_extra
+
+@pytest.mark.asyncio
+async def test_validate_extra_people_names_commas_only_when_extras_expected(sample_event):
+    """Test validation with commas only when extras are expected."""
+    modal = GatheringModal(event=sample_event)
+    with pytest.raises(ValidationError) as exc_info:
+        modal._validate_extra_people_names(",,,,", 2)
+    assert "Please provide exactly 2 non-empty name(s)" in str(exc_info.value)
 
 
-# Note: Integration tests with GatheringModal.on_submit are more complex
-# because they require an async event loop and proper Discord.py context.
-# The unit tests above cover the validation logic itself.
-# End-to-end testing of the modal submission should be done manually or
-# with a more comprehensive test framework that can handle Discord.py modals.
+@pytest.mark.asyncio
+async def test_validate_extra_people_names_trailing_comma_accepted(sample_event):
+    """Test that a trailing comma is ignored, treating it as correct count."""
+    modal = GatheringModal(event=sample_event)
+    names = modal._validate_extra_people_names("Alice, Bob, ", 2)
+    assert names == ["Alice", "Bob"]


### PR DESCRIPTION
### Summary

  This PR fixes an issue where users could register extra guests without mentioning their names (leaving it blank or entering only commas/whitespace, which resulted in names displaying as   (username +1)  in
  the attendee list).

  ### Changes

  1. Robust Extras Validation:
      • Enforces that names must be provided for all extra guests when  extra_people > 0 .
      • Strips whitespace and filters out any empty values to prevent bypassing validation (e.g. entering  , , , ,  or  , ).
      • Rejects any entries in the guest names field if the user specifies bringing  0  extra people.
      • Cleans up trailing commas gracefully if the correct number of names is provided (e.g.,  Alice, Bob,   is parsed as  ["Alice", "Bob"] ).
  2. Test Coverage Updates:
      • Rewrote the unit tests in  test_extras_names_validation.py  to run within an active event loop and assert against all edge cases.
      • Updated existing mock registrations in  test_capacity_waitlist.py  to specify valid mock guest names so they comply with the new validation rules.