### PR TITLE
fix: log startup warning when FRONTEND_URL is not configured (#83)

### DIFF
--- a/bot/src/offkai_bot/main.py
+++ b/bot/src/offkai_bot/main.py
@@ -12,6 +12,7 @@ from discord.ext import commands
 from offkai_bot import config
 from offkai_bot.alerts.alerts import alert_loop
 from offkai_bot.alerts.reminders import register_checkin_reminder, register_deadline_reminders
+from offkai_bot.config import get_config
 
 # Import only necessary data loaders for initial cache population
 from offkai_bot.data.event import load_event_data
@@ -82,6 +83,9 @@ class OffkaiClient(commands.Bot):
         load_responses()  # Loads both attendees and waitlist
         load_rankings()
         _log.info("Initial data loaded into cache.")
+
+        if not get_config().get("FRONTEND_URL"):
+            _log.warning("FRONTEND_URL is not set — check-in URLs will be omitted from DMs.")
 
         # Sync commands
         for guild_id in settings["GUILDS"]:


### PR DESCRIPTION
Closes #83.

When `FRONTEND_URL` is absent from config, `build_checkin_url()` silently returns `""` and the QR/RSVP link is omitted from all check-in reminder DMs and signup confirmations — with no log entry and no operator feedback.

**Fix:** one-time `WARNING` log in `setup_hook` when `FRONTEND_URL` is not configured, so operators know the feature is disabled on startup rather than discovering it through missing links in DMs.

No behaviour change — `build_checkin_url` still returns `""` when unset; only observability is added.