### PR TITLE
Forward  FRONTEND_URL  and  ADMIN_KEY  to the Discord Bot Docker Container

### DIFF
--- a/bot/compose.yml
+++ b/bot/compose.yml
@@ -10,4 +10,6 @@ services:
     environment:
       - DISCORD_TOKEN=${DISCORD_TOKEN}
       - GUILDS=${GUILDS}
+      - FRONTEND_URL=${FRONTEND_URL}
+      - ADMIN_KEY=${ADMIN_KEY}
     restart: unless-stopped

--- a/compose.yml
+++ b/compose.yml
@@ -10,6 +10,8 @@ services:
     environment:
       - DISCORD_TOKEN=${DISCORD_TOKEN}
       - GUILDS=${GUILDS}
+      - FRONTEND_URL=${FRONTEND_URL}
+      - ADMIN_KEY=${ADMIN_KEY}
     restart: unless-stopped
 
   chibachanners-frontend:


### PR DESCRIPTION
This PR resolves the issue where the bot is unable to read  FRONTEND_URL  or  ADMIN_KEY  from the host environment, causing check-in and RSVP links in user DMs to be omitted and triggering the warning:
   FRONTEND_URL is not set — check-in URLs will be omitted from DMs. 

  Even if these values are correctly specified in the server's  .env  file, Docker Compose does not forward them to individual services by default. This change explicitly defines both  FRONTEND_URL  and        
  ADMIN_KEY  environment variables inside the  discord-offkai-bot  service definition across all Compose configurations.

  ### Changes

  • compose.yml: Added  FRONTEND_URL  and  ADMIN_KEY  environment forwarding to the bot container definition.
  • compose.yml: Mirror the environment forwarding setup for local bot development environment.