### PR TITLE
fix: preserve Discord user IDs as strings to stop JSON precision loss (#86)

### DIFF
--- a/frontend/app/admin/page.tsx
+++ b/frontend/app/admin/page.tsx
@@ -3,7 +3,8 @@ import { useState, useEffect, useRef, useCallback } from 'react'
 import { flushSync } from 'react-dom'
 
 type Attendee = {
-  user_id: number
+  // Discord snowflake ID as a string (64-bit, exceeds JS safe-integer range).
+  user_id: string
   username: string
   display_name: string | null
   drinks: string[]
@@ -13,7 +14,7 @@ type Attendee = {
 }
 
 type CheckinRecord = {
-  user_id: number
+  user_id: string
   event_name: string
   checked_in_at: string
   name: string
@@ -69,14 +70,14 @@ export default function AdminPage() {
   const [events, setEvents] = useState<EventOption[]>([])
   const [selectedEvent, setSelectedEvent] = useState('')
   const [attendees, setAttendees] = useState<Attendee[]>([])
-  const [checkins, setCheckins] = useState<Record<number, CheckinRecord>>({})
+  const [checkins, setCheckins] = useState<Record<string, CheckinRecord>>({})
   const [scanning, setScanning] = useState(false)
   const [scanResult, setScanResult] = useState<ScanResult | null>(null)
   const [filter, setFilter] = useState<'all' | 'checked' | 'pending'>('all')
   const [search, setSearch] = useState('')
   // Rows the admin just checked in/out — kept visible regardless of the active
   // filter so a mistaken action can be undone in place (e.g. on the Pending tab).
-  const [stickyIds, setStickyIds] = useState<Set<number>>(new Set())
+  const [stickyIds, setStickyIds] = useState<Set<string>>(new Set())
 
   const scannerRef = useRef<{ stop: () => Promise<void>; clear?: () => void } | null>(null)
   const Html5QrcodeRef = useRef<typeof import('html5-qrcode').Html5Qrcode | null>(null)
@@ -171,7 +172,7 @@ export default function AdminPage() {
   }, [authed, selectedEvent, key, loadCheckins])
 
   // Manual check-in (admin button) — no QR needed, admin is already authed.
-  const manualCheckin = useCallback(async (userId: number) => {
+  const manualCheckin = useCallback(async (userId: string) => {
     const evParam = selectedEvent ? `&event=${encodeURIComponent(selectedEvent)}` : ''
     const res = await fetch(`/api/checkin?key=${encodeURIComponent(key)}${evParam}`, {
       method: 'POST',
@@ -187,7 +188,7 @@ export default function AdminPage() {
 
   // Manual check-out (admin button) — removes the check-in for this event.
   // Uses POST with action=checkout because some proxies reject the DELETE method.
-  const manualCheckout = useCallback(async (userId: number) => {
+  const manualCheckout = useCallback(async (userId: string) => {
     const evParam = selectedEvent ? `&event=${encodeURIComponent(selectedEvent)}` : ''
     const res = await fetch(`/api/checkin?key=${encodeURIComponent(key)}${evParam}`, {
       method: 'POST',

--- a/frontend/app/api/attendee/route.ts
+++ b/frontend/app/api/attendee/route.ts
@@ -22,7 +22,7 @@ export async function GET(request: NextRequest) {
     if (!eventName || !MOCK_ATTENDEES[eventName]) {
       return NextResponse.json({ error: 'not_found' }, { status: 404 })
     }
-    const mockA = findMockAttendee(eventName, Number(resolved.userId))
+    const mockA = findMockAttendee(eventName, resolved.userId)
     if (!mockA) return NextResponse.json({ error: 'not_found' }, { status: 404 })
     const ev = MOCK_EVENTS.find(e => e.event_name === eventName)!
     const isCheckedIn = mockCheckins.some(c => c.user_id === mockA.user_id && c.event_name === eventName)
@@ -59,10 +59,10 @@ export async function GET(request: NextRequest) {
   }
 
   const uid = resolved.userId
-  let attendee = (eventResponses.attendees || []).find(a => a.user_id.toString() === uid)
+  let attendee = (eventResponses.attendees || []).find(a => a.user_id === uid)
   let isWaitlist = false
   if (!attendee) {
-    attendee = (eventResponses.waitlist || []).find(a => a.user_id.toString() === uid)
+    attendee = (eventResponses.waitlist || []).find(a => a.user_id === uid)
     if (attendee) isWaitlist = true
   }
   if (!attendee) {

--- a/frontend/app/api/checkin/route.ts
+++ b/frontend/app/api/checkin/route.ts
@@ -26,7 +26,7 @@ type CheckInOutcome =
   | { kind: 'write_error' }
 
 type CheckOutOutcome =
-  | { kind: 'checked_out'; user_id: number; event_name: string }
+  | { kind: 'checked_out'; user_id: string; event_name: string }
   | { kind: 'event_not_found' }
   | { kind: 'event_archived' }
   | { kind: 'attendee_not_in_event' }
@@ -36,13 +36,13 @@ type CheckOutOutcome =
 // Resolves an *attending* attendee for an event (works in mock + real mode).
 // Returns the display name, or an error kind.
 function resolveAttendee(eventName: string, userId: string):
-  | { ok: true; user_id: number; name: string }
+  | { ok: true; user_id: string; name: string }
   | { ok: false; kind: 'event_not_found' | 'event_archived' | 'attendee_not_in_event' } {
   if (MOCK_MODE) {
     const ev = MOCK_EVENTS.find(e => e.event_name === eventName)
     if (!ev || !MOCK_ATTENDEES[eventName]) return { ok: false, kind: 'event_not_found' }
     if (ev.archived) return { ok: false, kind: 'event_archived' }
-    const a = findMockAttendee(eventName, Number(userId))
+    const a = findMockAttendee(eventName, userId)
     if (!a || a.status !== 'attending') return { ok: false, kind: 'attendee_not_in_event' }
     return { ok: true, user_id: a.user_id, name: a.display_name || a.username }
   }
@@ -51,7 +51,7 @@ function resolveAttendee(eventName: string, userId: string):
   if (!ev) return { ok: false, kind: 'event_not_found' }
   if (ev.archived) return { ok: false, kind: 'event_archived' }
   const er = readResponses()[eventName]
-  const a = (er?.attendees || []).find(x => x.user_id.toString() === userId)
+  const a = (er?.attendees || []).find(x => x.user_id === userId)
   if (!a) return { ok: false, kind: 'attendee_not_in_event' }
   return { ok: true, user_id: a.user_id, name: a.display_name || a.username }
 }

--- a/frontend/app/api/db.ts
+++ b/frontend/app/api/db.ts
@@ -15,7 +15,9 @@ export interface Event {
 }
 
 export interface BotAttendee {
-  user_id: number
+  // Discord snowflake IDs are 64-bit and exceed JS Number.MAX_SAFE_INTEGER, so
+  // they are kept as strings end-to-end to avoid precision loss (see parseBotJson).
+  user_id: string
   username: string
   display_name: string | null
   drinks: string[]
@@ -37,7 +39,7 @@ export interface BotResponses {
 }
 
 export interface CheckinRecord {
-  user_id: number
+  user_id: string
   event_name: string
   checked_in_at: string
   name: string
@@ -45,6 +47,17 @@ export interface CheckinRecord {
 
 const BOT_DATA_DIR = process.env.BOT_DATA_DIR ||
   (fs.existsSync('/app/offkai-bot-data') ? '/app/offkai-bot-data' : path.join(process.cwd(), '..', 'data'))
+
+// The bot serializes Discord user IDs as JSON numbers, but they are 64-bit
+// snowflakes that exceed Number.MAX_SAFE_INTEGER — a plain JSON.parse silently
+// rounds them (e.g. 191524132624531458 -> 191524132624531460), so they no
+// longer match the exact ID carried in a check-in token. Quote every
+// `"user_id": <digits>` before parsing so the value is preserved exactly as a
+// string. Already-quoted values (e.g. checkins.json written by this app) are
+// left untouched.
+function parseBotJson<T>(text: string): T {
+  return JSON.parse(text.replace(/("user_id"\s*:\s*)(\d+)/g, '$1"$2"')) as T
+}
 
 export function getEventsFilePath() {
   return path.join(BOT_DATA_DIR, 'events.json')
@@ -75,7 +88,7 @@ export function readResponses(): BotResponses {
   if (!fs.existsSync(filePath)) return {}
   try {
     const data = fs.readFileSync(filePath, 'utf8')
-    return JSON.parse(data)
+    return parseBotJson<BotResponses>(data)
   } catch (e) {
     console.error('Error reading responses:', e)
     return {}
@@ -87,7 +100,7 @@ export function readCheckins(): CheckinRecord[] {
   if (!fs.existsSync(filePath)) return []
   try {
     const data = fs.readFileSync(filePath, 'utf8')
-    return JSON.parse(data)
+    return parseBotJson<CheckinRecord[]>(data)
   } catch (e) {
     console.error('Error reading checkins:', e)
     return []

--- a/frontend/app/api/mock.ts
+++ b/frontend/app/api/mock.ts
@@ -17,7 +17,8 @@ export interface MockEvent {
 }
 
 export interface MockAttendee {
-  user_id: number
+  // String to match the real BotAttendee.user_id (Discord snowflakes are 64-bit).
+  user_id: string
   username: string
   display_name: string | null
   drinks: string[]
@@ -72,24 +73,24 @@ export const MOCK_EVENTS: MockEvent[] = [
 // Distinct attendees per event so cross-event scans can be rejected.
 export const MOCK_ATTENDEES: Record<string, MockAttendee[]> = {
   'Bandori 10th Offkai': [
-    { user_id: 123, username: 'fadekyun', display_name: 'Fadekyun', drinks: ['Highball (L)'], extra_people: 1, extras_names: ['Senpai'], status: 'attending' },
-    { user_id: 124, username: 'sakichan', display_name: 'Sakichan', drinks: ['Oolong Tea (L)', 'Cream Soda (L)'], extra_people: 0, extras_names: [], status: 'attending' },
-    { user_id: 125, username: 'hoshino', display_name: 'Hoshino', drinks: ['Sapporo Beer (L)'], extra_people: 2, extras_names: ['Friend A', 'Friend B'], status: 'attending' },
-    { user_id: 126, username: 'arisa', display_name: 'Arisa', drinks: ['Fresh Lemon Sour (L)'], extra_people: 0, extras_names: [], status: 'waitlist' },
+    { user_id: '123', username: 'fadekyun', display_name: 'Fadekyun', drinks: ['Highball (L)'], extra_people: 1, extras_names: ['Senpai'], status: 'attending' },
+    { user_id: '124', username: 'sakichan', display_name: 'Sakichan', drinks: ['Oolong Tea (L)', 'Cream Soda (L)'], extra_people: 0, extras_names: [], status: 'attending' },
+    { user_id: '125', username: 'hoshino', display_name: 'Hoshino', drinks: ['Sapporo Beer (L)'], extra_people: 2, extras_names: ['Friend A', 'Friend B'], status: 'attending' },
+    { user_id: '126', username: 'arisa', display_name: 'Arisa', drinks: ['Fresh Lemon Sour (L)'], extra_people: 0, extras_names: [], status: 'waitlist' },
   ],
   'Roselia Live Offkai': [
-    { user_id: 200, username: 'yukina', display_name: 'Yukina', drinks: ['Oolong Tea (L)'], extra_people: 0, extras_names: [], status: 'attending' },
-    { user_id: 201, username: 'lisa', display_name: 'Lisa', drinks: ['Sapporo Beer (L)'], extra_people: 1, extras_names: ['Ako'], status: 'attending' },
+    { user_id: '200', username: 'yukina', display_name: 'Yukina', drinks: ['Oolong Tea (L)'], extra_people: 0, extras_names: [], status: 'attending' },
+    { user_id: '201', username: 'lisa', display_name: 'Lisa', drinks: ['Sapporo Beer (L)'], extra_people: 1, extras_names: ['Ako'], status: 'attending' },
   ],
   'MyGO!!!!! Offkai': [
-    { user_id: 300, username: 'tomori', display_name: 'Tomori', drinks: ['Cream Soda (L)'], extra_people: 0, extras_names: [], status: 'attending' },
-    { user_id: 301, username: 'anon', display_name: 'Anon', drinks: ['Fresh Lemon Sour (L)'], extra_people: 0, extras_names: [], status: 'attending' },
+    { user_id: '300', username: 'tomori', display_name: 'Tomori', drinks: ['Cream Soda (L)'], extra_people: 0, extras_names: [], status: 'attending' },
+    { user_id: '301', username: 'anon', display_name: 'Anon', drinks: ['Fresh Lemon Sour (L)'], extra_people: 0, extras_names: [], status: 'attending' },
   ],
 }
 
 // Process-wide in-memory check-ins for mock mode (resets on server restart).
 export const mockCheckins: CheckinRecord[] = []
 
-export function findMockAttendee(eventName: string, userId: number): MockAttendee | undefined {
+export function findMockAttendee(eventName: string, userId: string): MockAttendee | undefined {
   return (MOCK_ATTENDEES[eventName] || []).find(a => a.user_id === userId)
 }

--- a/frontend/app/api/validation.ts
+++ b/frontend/app/api/validation.ts
@@ -15,9 +15,17 @@ export function parseEventParam(raw: unknown): string | null | false {
 
 // Validates a manual user_id (number or numeric string).
 // Returns the canonical string form, or null if invalid.
+//
+// Discord IDs are 64-bit snowflakes that exceed Number.MAX_SAFE_INTEGER, so a
+// digit-string is validated and returned verbatim — never round-tripped through
+// Number(), which would silently corrupt it (191524132624531458 -> ...460).
 export function parseUserId(raw: unknown): string | null {
-  if (typeof raw !== 'number' && typeof raw !== 'string') return null
-  const n = Number(raw)
-  if (!Number.isFinite(n) || !Number.isInteger(n) || n < 0) return null
-  return String(n)
+  if (typeof raw === 'string') {
+    const trimmed = raw.trim()
+    return /^\d+$/.test(trimmed) ? trimmed : null
+  }
+  if (typeof raw === 'number') {
+    return Number.isInteger(raw) && raw >= 0 ? String(raw) : null
+  }
+  return null
 }


### PR DESCRIPTION
Closes #86.

## Problem

Discord user IDs are 64-bit snowflakes (18–19 digits) that exceed JS `Number.MAX_SAFE_INTEGER` (2⁵³). The frontend read `responses.json` / `checkins.json` with plain `JSON.parse`, which **silently rounds** them:

```
JSON.parse('{"user_id":191524132624531458}').user_id  ->  191524132624531460
```

The mangled value never equals the **exact** ID carried in a check-in token (which stays a string through `verifyToken`), so:
- `/api/attendee?token=…` → **404** "RSVP Not Found" even with the correct `ADMIN_KEY` and the attendee present
- QR check-in (`/api/checkin`) fails the same way
- `parseUserId` had the same flaw (`Number(raw)` round-trip), breaking **manual admin check-in** too

The bot serializes `user_id` as a JSON number (`Response.user_id: int` → `asdict` + `json.dump`), so every real data file carries the landmine. It was missed because test/staging runs `MOCK_MODE=true`, which uses small in-memory IDs and bypasses the file-parse path.

## Verified

| `user_id` in `responses.json` | `/api/attendee?token=…` |
|---|---|
| `191524132624531458` (number) | 404 — before |
| same, with this fix | **200 OK** |
| bad signature | 401 (unchanged) |

Round-trip check: an 18-digit ID read from a number-format file now comes back as the exact string `"191524132624531458"` and matches the token.

## Change

Treat `user_id` as a string throughout the bot-data layer:

- **`db.ts`** — `parseBotJson()` quotes `"user_id": <digits>` before `JSON.parse`, preserving the exact value as a string (already-quoted values untouched). Used in `readResponses` / `readCheckins`. `BotAttendee.user_id` / `CheckinRecord.user_id` typed `string`.
- **`validation.ts`** — `parseUserId` validates a digit-string and returns it verbatim, never via `Number()`.
- **`mock.ts`** — mock IDs are strings; `findMockAttendee` takes a string.
- **`attendee` / `checkin` routes + `admin/page.tsx`** — compare `user_id` by string equality.

Self-contained in the frontend. Reads **existing numeric files** correctly (no migration) and writes string IDs going forward.

Frontend `eslint` + `next build` (TypeScript) pass.