### PR TITLE
feat: emit event-bound v2 check-in tokens so reminder links resolve to the right event

### DIFF
--- a/bot/src/offkai_bot/alerts/reminders.py
+++ b/bot/src/offkai_bot/alerts/reminders.py
@@ -189,7 +189,7 @@ class SendCheckinReminderTask(Task):
         sent = 0
         for index, response in enumerate(attendees):
             # Per-attendee private URL using the shared token helper.
-            rsvp_url = build_checkin_url(response.user_id)
+            rsvp_url = build_checkin_url(response.user_id, self.event_name)
             message = build_checkin_reminder_message(event, response, rsvp_url)
             try:
                 # DM the individual user. fetch_user + user.send opens a private

--- a/bot/src/offkai_bot/interactions.py
+++ b/bot/src/offkai_bot/interactions.py
@@ -178,7 +178,7 @@ async def promote_waitlist_batch(event: Event, client: discord.Client) -> list[i
 
         # Notify the promoted user
         try:
-            rsvp_url = build_checkin_url(promoted_entry.user_id)
+            rsvp_url = build_checkin_url(promoted_entry.user_id, event.event_name)
             rsvp_link_msg = f"\n🔗 **RSVP Page / QR Code:** {rsvp_url}" if rsvp_url else ""
             rsvp_link_msg_jp = f"\n🔗 **RSVPページ / QRコード:** {rsvp_url}" if rsvp_url else ""
 
@@ -370,7 +370,7 @@ class GatheringModal(ui.Modal):
 
     async def _handle_successful_submission(self, interaction: discord.Interaction, response: Response):
         """Handles actions after a response is successfully added."""
-        rsvp_url = build_checkin_url(response.user_id)
+        rsvp_url = build_checkin_url(response.user_id, response.event_name)
         rsvp_link_msg = f"\n🔗 **RSVP Page / QR Code:** {rsvp_url}" if rsvp_url else ""
         rsvp_link_msg_jp = f"\n🔗 **RSVPページ / QRコード:** {rsvp_url}" if rsvp_url else ""
 

--- a/bot/src/offkai_bot/util.py
+++ b/bot/src/offkai_bot/util.py
@@ -1,4 +1,5 @@
 # src/offkai_bot/util.py
+import base64
 import functools
 import hashlib
 import hmac
@@ -146,28 +147,48 @@ def log_command_usage(func):
 
 
 def generate_checkin_signature(user_id: int, secret_key: str) -> str:
-    """Computes a 16-character HMAC-SHA256 signature of a user_id using the secret_key."""
+    """Computes a 16-character HMAC-SHA256 signature of a user_id using the secret_key.
+
+    This is the *legacy* (event-less) token signature. The frontend still accepts
+    legacy tokens, but ``build_checkin_url`` now emits the event-bound v2 format
+    via ``build_checkin_token`` so a link can never resolve to the wrong event.
+    """
     if not secret_key:
         return ""
     h = hmac.new(secret_key.encode("utf-8"), str(user_id).encode("utf-8"), hashlib.sha256)
     return h.hexdigest()[:16]
 
 
-def build_checkin_url(user_id: int) -> str:
-    """Returns the attendee's personal check-in URL, or '' if FRONTEND_URL is not configured.
+def build_checkin_token(user_id: int, event_name: str, secret_key: str) -> str:
+    """Builds the event-bound v2 check-in token: ``v2.<payload>.<sig>`` where
+    ``payload = base64url(user_id:event_name)`` (no padding) and
+    ``sig = HMAC-SHA256(secret_key, payload)[:16]``.
 
-    Centralises the token-construction logic that was previously copy-pasted
-    across interactions.py and reminders.py so a future token-format change
-    only needs to be made in one place.
+    This mirrors the verifier in ``frontend/app/api/token.ts``. Binding the event
+    into the signed token means a reminder/signup link always resolves to the
+    event it was issued for, instead of falling back to the frontend's
+    "default event" guess when several events are open at once.
+    """
+    payload_bytes = f"{user_id}:{event_name}".encode()
+    payload = base64.urlsafe_b64encode(payload_bytes).rstrip(b"=").decode("ascii")
+    sig = hmac.new(secret_key.encode("utf-8"), payload.encode("utf-8"), hashlib.sha256).hexdigest()[:16]
+    return f"v2.{payload}.{sig}"
+
+
+def build_checkin_url(user_id: int, event_name: str) -> str:
+    """Returns the attendee's personal, event-bound check-in URL, or '' if
+    FRONTEND_URL is not configured.
+
+    With ADMIN_KEY set, emits a signed v2 token bound to ``event_name`` so the
+    link can only ever resolve to that event. Without a key, falls back to the
+    bare user_id that the keyless frontend accepts. Centralises token
+    construction so the three call sites (signup, waitlist promotion, reminder)
+    stay in sync.
     """
     settings = get_config()
     frontend_url = settings.get("FRONTEND_URL", "")
     if not frontend_url:
         return ""
     admin_key = settings.get("ADMIN_KEY", "")
-    token = str(user_id)
-    if admin_key:
-        sig = generate_checkin_signature(user_id, admin_key)
-        if sig:
-            token = f"{user_id}.{sig}"
+    token = build_checkin_token(user_id, event_name, admin_key) if admin_key else str(user_id)
     return f"{frontend_url}/?token={token}"

--- a/bot/tests/test_util.py
+++ b/bot/tests/test_util.py
@@ -1,5 +1,8 @@
 # tests/test_util.py
 
+import base64
+import hashlib
+import hmac
 from datetime import UTC, datetime, timedelta
 from unittest.mock import MagicMock, patch
 
@@ -14,9 +17,10 @@ from offkai_bot.errors import (
 )
 
 # Import functions and errors from the module under test
-# Import build_checkin_url for its own test section below
+# Import build_checkin_url / build_checkin_token for their own test sections below
 from offkai_bot.util import (
     JST,
+    build_checkin_token,
     build_checkin_url,
     generate_checkin_signature,
     parse_drinks,
@@ -299,6 +303,50 @@ def test_validate_event_deadline_past_error_takes_precedence(mock_dt):
     mock_dt.now.assert_called_once_with(UTC)
 
 
+# --- Tests for generate_checkin_signature (legacy, event-less) ---
+
+
+def test_generate_checkin_signature_matches_hmac():
+    """Legacy signature is HMAC-SHA256(secret, str(user_id))[:16]."""
+    expected = hmac.new(b"mykey", b"4242", hashlib.sha256).hexdigest()[:16]
+    assert generate_checkin_signature(4242, "mykey") == expected
+
+
+def test_generate_checkin_signature_empty_key_returns_empty():
+    """No secret key → empty signature (keyless deployments)."""
+    assert generate_checkin_signature(4242, "") == ""
+
+
+# --- Tests for build_checkin_token (v2 event-bound) ---
+
+
+def test_build_checkin_token_v2_format_and_signature():
+    """v2 token is v2.<base64url(user_id:event_name)>.<16-char HMAC over payload>."""
+    token = build_checkin_token(4242, "Summer Bash", "mykey")
+    parts = token.split(".")
+    assert len(parts) == 3
+    assert parts[0] == "v2"
+
+    payload, sig = parts[1], parts[2]
+    # Payload has no '=' padding (URL-safe, matches the frontend verifier).
+    assert "=" not in payload
+    # Payload decodes back to the exact "user_id:event_name".
+    decoded = base64.urlsafe_b64decode(payload + "=" * (-len(payload) % 4)).decode()
+    assert decoded == "4242:Summer Bash"
+    # Signature is HMAC-SHA256(secret, payload)[:16], matching token.ts.
+    expected_sig = hmac.new(b"mykey", payload.encode(), hashlib.sha256).hexdigest()[:16]
+    assert sig == expected_sig
+
+
+def test_build_checkin_token_v2_preserves_large_discord_id():
+    """An 18-digit Discord ID round-trips exactly (no JS-style precision loss)."""
+    uid = 191524132624531458
+    token = build_checkin_token(uid, "niji 8l tokyo d2", "k")
+    payload = token.split(".")[1]
+    decoded = base64.urlsafe_b64decode(payload + "=" * (-len(payload) % 4)).decode()
+    assert decoded == f"{uid}:niji 8l tokyo d2"
+
+
 # --- Tests for build_checkin_url ---
 
 
@@ -306,31 +354,32 @@ def test_validate_event_deadline_past_error_takes_precedence(mock_dt):
 def test_build_checkin_url_no_frontend_url(mock_get_config):
     """Returns '' when FRONTEND_URL is not configured."""
     mock_get_config.return_value = {"FRONTEND_URL": "", "ADMIN_KEY": "secret"}
-    assert build_checkin_url(42) == ""
+    assert build_checkin_url(42, "Summer Bash") == ""
 
 
 @patch("offkai_bot.util.get_config")
 def test_build_checkin_url_no_admin_key_uses_bare_user_id(mock_get_config):
-    """Without ADMIN_KEY the token is just the bare user_id."""
+    """Without ADMIN_KEY the token is just the bare user_id (keyless frontend)."""
     mock_get_config.return_value = {"FRONTEND_URL": "https://offkai.example", "ADMIN_KEY": ""}
-    result = build_checkin_url(99)
+    result = build_checkin_url(99, "Summer Bash")
     assert result == "https://offkai.example/?token=99"
 
 
 @patch("offkai_bot.util.get_config")
-def test_build_checkin_url_with_admin_key_produces_signed_token(mock_get_config):
-    """With ADMIN_KEY the token is <user_id>.<16-char HMAC> — same as generate_checkin_signature."""
+def test_build_checkin_url_with_admin_key_produces_v2_token(mock_get_config):
+    """With ADMIN_KEY the URL carries the event-bound v2 token."""
     mock_get_config.return_value = {"FRONTEND_URL": "https://offkai.example", "ADMIN_KEY": "mykey"}
-    result = build_checkin_url(4242)
+    result = build_checkin_url(4242, "Summer Bash")
 
-    expected_sig = generate_checkin_signature(4242, "mykey")
-    assert result == f"https://offkai.example/?token=4242.{expected_sig}"
+    expected_token = build_checkin_token(4242, "Summer Bash", "mykey")
+    assert result == f"https://offkai.example/?token={expected_token}"
+    assert "/?token=v2." in result
 
 
 @patch("offkai_bot.util.get_config")
 def test_build_checkin_url_missing_keys_default_to_empty(mock_get_config):
     """Keys absent from config dict are treated as empty strings — no KeyError."""
     mock_get_config.return_value = {"FRONTEND_URL": "https://offkai.example"}
-    result = build_checkin_url(7)
+    result = build_checkin_url(7, "Summer Bash")
     # No ADMIN_KEY → bare user_id token.
     assert result == "https://offkai.example/?token=7"


### PR DESCRIPTION
Implements the deferred P1 from #82 review (event-bound token for reminder links).

## Problem

The reminder / signup-confirmation / waitlist-promotion DMs carried a **legacy, event-less** token (`<user_id>.<sig>`). The frontend resolves a legacy token via `getDefaultEvent` — the nearest upcoming event — so when more than one event is open at once, a link can resolve to the **wrong event** and return 404 for an attendee who isn't in that default (e.g. a day-2 attendee whose link resolves to day-1).

The frontend has **already** verified the event-bound v2 format since #78 (`frontend/app/api/token.ts`). The bot just never emitted it.

## Change

- **`util.py`** — `build_checkin_token(user_id, event_name, secret_key)` builds `v2.<payload>.<sig>` where `payload = base64url(user_id:event_name)` (no padding) and `sig = HMAC-SHA256(secret_key, payload)[:16]`, mirroring the frontend verifier. `build_checkin_url(user_id, event_name)` emits v2 when `ADMIN_KEY` is set, else the bare `user_id` the keyless frontend accepts.
- Pass the event name at all three call sites: signup confirmation, waitlist promotion, check-in reminder.
- `generate_checkin_signature` retained (the frontend still accepts legacy tokens) and given direct unit tests.

## Verification

Cross-checked Python ↔ frontend: a token minted by `build_checkin_token` passes the frontend's `verifyToken` and decodes to the exact `user_id` + `event_name`:

```
v2.MTkxNTI0MTMyNjI0NTMxNDU4Om5pamkgOGwgdG9reW8gZDI.e45e5926d4a4e999
-> userId: 191524132624531458  event: niji 8l tokyo d2
```

Bonus: v2 also sidesteps the 64-bit-ID precision issue (#86), since the `user_id` comes from the decoded payload rather than `JSON.parse`.

`ruff` + `ty` clean; `pytest` **490 passing** (new tests for `build_checkin_token`, the large-ID round-trip, and `generate_checkin_signature`).

> Note: independent of the frontend precision fix (#87). Both can land in either order; together they make reminder links resolve to the correct attendee **and** the correct event.