### PR TITLE
feat(frontend): Offkai Bot izakaya brand identity (matsuri redesign)

### DIFF
--- a/frontend/app/admin/page.tsx
+++ b/frontend/app/admin/page.tsx
@@ -26,17 +26,17 @@ type EventOption = {
   open: boolean
 }
 
-// Scanner result is keyed by a stable `kind` (not display wording) so the icon
+// Scanner result is keyed by a stable `kind` (not display wording) so the badge
 // and styling stay correct even if the copy changes.
 type ScanResultKind = 'checked_in' | 'already_checked_in' | 'wrong_event' | 'invalid_qr' | 'error'
 type ScanResult = { kind: ScanResultKind; name: string }
 
-const SCAN_RESULT_META: Record<ScanResultKind, { ok: boolean; icon: string; title: string }> = {
-  checked_in:         { ok: true,  icon: '✅', title: 'Checked In!' },
-  already_checked_in: { ok: true,  icon: '🔄', title: 'Already Checked In' },
-  wrong_event:        { ok: false, icon: '⛔', title: 'Wrong Event' },
-  invalid_qr:         { ok: false, icon: '❌', title: 'Invalid QR' },
-  error:              { ok: false, icon: '❌', title: 'Camera Error' },
+const SCAN_RESULT_META: Record<ScanResultKind, { ok: boolean; badge: string; title: string }> = {
+  checked_in:         { ok: true,  badge: 'OK',    title: 'Checked In!' },
+  already_checked_in: { ok: true,  badge: 'Again', title: 'Already Checked In' },
+  wrong_event:        { ok: false, badge: 'Stop',  title: 'Wrong Event' },
+  invalid_qr:         { ok: false, badge: 'NG',    title: 'Invalid QR' },
+  error:              { ok: false, badge: 'NG',    title: 'Camera Error' },
 }
 
 function drinkDot(name: string) {
@@ -62,10 +62,42 @@ function formatEventLabel(ev: EventOption) {
   return `${ev.event_name}${when}${ev.open ? '' : ' (closed)'}`
 }
 
+function SmileyMark({ className = '' }: { className?: string }) {
+  return (
+    <svg viewBox="0 0 40 40" className={className} aria-hidden="true">
+      <circle cx="20" cy="20" r="18" fill="#E51F1F" stroke="#17120F" strokeWidth="2.5" />
+      <circle cx="13" cy="16.5" r="2.6" fill="#17120F" />
+      <circle cx="27" cy="16.5" r="2.6" fill="#17120F" />
+      <path d="M11 22 q9 11 18 0" fill="none" stroke="#17120F" strokeWidth="3" strokeLinecap="round" />
+    </svg>
+  )
+}
+
+function BrandSign({ compact = false }: { compact?: boolean }) {
+  if (compact) {
+    return (
+      <div className="inline-flex items-center gap-1.5">
+        <SmileyMark className="h-7 w-7 shrink-0 -rotate-6" />
+        <span className="brand-wordmark text-2xl leading-none">Offkai Bot</span>
+      </div>
+    )
+  }
+  return (
+    <div className="inline-flex flex-col items-start">
+      <span className="brand-banner inline-block rounded-lg px-2.5 py-0.5 text-[10px] tracking-[0.3em]">大衆酒場</span>
+      <div className="mt-1.5 flex items-end gap-1">
+        <span className="brand-wordmark text-4xl leading-[0.9]">Offkai Bot</span>
+        <SmileyMark className="mb-1 h-7 w-7 shrink-0 -rotate-6 drop-shadow-[2px_2px_0_#17120F]" />
+      </div>
+    </div>
+  )
+}
+
 export default function AdminPage() {
   const [key, setKey] = useState('')
   const [authed, setAuthed] = useState(false)
   const [keyInput, setKeyInput] = useState('')
+  const [loginError, setLoginError] = useState('')
   const [eventName, setEventName] = useState('')
   const [events, setEvents] = useState<EventOption[]>([])
   const [selectedEvent, setSelectedEvent] = useState('')
@@ -135,8 +167,8 @@ export default function AdminPage() {
 
   const handleLogin = async () => {
     const ok = await initialLoad(keyInput)
-    if (ok) { setKey(keyInput); setAuthed(true) }
-    else alert('Invalid key')
+    if (ok) { setKey(keyInput); setAuthed(true); setLoginError('') }
+    else setLoginError('Invalid key. Check with the event host.')
   }
 
   // Refresh attendee list + check-ins whenever the selected event changes.
@@ -317,6 +349,8 @@ export default function AdminPage() {
   const checkedInCount = attendees
     .filter(a => a.status === 'attending' && checkins[a.user_id])
     .reduce((total, a) => total + groupSize(a), 0)
+  const pendingCount = attendingCount - checkedInCount
+  const waitlistCount = attendees.filter(a => a.status === 'waitlist').length
 
   const filtered = attendees
     .filter(a => a.status === 'attending')
@@ -328,27 +362,39 @@ export default function AdminPage() {
     })
     .filter(a => {
       if (!search) return true
-      const name = (a.display_name || a.username).toLowerCase()
-      return name.includes(search.toLowerCase())
+      const q = search.toLowerCase().replace(/^[@#]/, '')
+      return [a.display_name || '', a.username, a.user_id, ...a.drinks, ...a.extras_names]
+        .some(v => v.toLowerCase().includes(q))
     })
 
   if (!authed) {
     return (
-      <main className="min-h-screen bg-[#E1D9BC] flex items-center justify-center p-6">
-        <div className="bg-[#F0F0DB] p-8 rounded-3xl border border-[#ACBAC4] shadow-xl w-full max-w-sm">
-          <p className="text-[10px] font-black uppercase tracking-widest text-[#30364F] opacity-60 mb-2">Staff Access</p>
-          <h1 className="text-xl font-black uppercase text-[#30364F] mb-6">Check-In Admin</h1>
+      <main className="brand-rays min-h-dvh flex items-center justify-center p-6">
+        <div className="brand-card w-full max-w-sm rounded-3xl p-7">
+          <BrandSign />
+          <p className="mt-7 text-[10px] font-black uppercase tracking-[0.22em] text-[#8B2D1F]">Staff Access</p>
+          <h1 className="mt-2 font-display text-2xl uppercase text-[#17120F] tracking-tight">Check-In Admin</h1>
+          <label htmlFor="admin-key" className="block text-[10px] font-black uppercase tracking-widest text-[#8B2D1F] mt-6 mb-2">
+            Admin key
+          </label>
           <input
+            id="admin-key"
             type="password"
             placeholder="Admin key"
             value={keyInput}
             onChange={e => setKeyInput(e.target.value)}
-            onKeyDown={e => e.key === 'Enter' && handleLogin()}
-            className="w-full border-2 border-[#ACBAC4] rounded-xl px-4 py-3 text-[#30364F] font-bold bg-white mb-4 outline-none focus:border-[#30364F]"
+            onKeyDown={e => e.key === 'Enter' && !!keyInput.trim() && handleLogin()}
+            aria-invalid={!!loginError}
+            aria-describedby={loginError ? 'admin-login-error' : undefined}
+            className="w-full border-2 border-[#17120F] rounded-xl px-4 py-3 text-[#17120F] font-bold bg-white mb-2 outline-none focus:border-[#E51F1F]"
           />
+          {loginError && (
+            <p id="admin-login-error" role="alert" className="text-sm font-bold text-red-700 mb-3">{loginError}</p>
+          )}
           <button
             onClick={handleLogin}
-            className="w-full bg-[#30364F] text-white font-black uppercase tracking-widest py-3 rounded-xl"
+            disabled={!keyInput.trim()}
+            className="brand-action w-full font-black uppercase tracking-widest py-3 rounded-xl mt-2 disabled:opacity-50 disabled:shadow-none"
           >
             Enter
           </button>
@@ -358,63 +404,84 @@ export default function AdminPage() {
   }
 
   return (
-    <main className="min-h-screen bg-[#E1D9BC] text-[#30364F] pb-12">
-      {/* Header */}
-      <div className="bg-[#30364F] text-white p-6 rounded-b-3xl shadow-xl">
-        <p className="text-[10px] font-black tracking-[0.2em] uppercase opacity-60 mb-1">Staff — Check-In</p>
-        <h1 className="text-xl font-black uppercase tracking-tight leading-tight">{eventName}</h1>
+    <main className="brand-bg min-h-dvh w-full max-w-6xl mx-auto text-[#23110D] pb-12">
+      <div className="sticky top-0 z-20 brand-sunburst text-white p-4 md:p-6 rounded-b-[1.5rem] md:rounded-b-[2rem] border-b-4 border-[#17120F] shadow-[0_6px_0_#17120F] md:shadow-[0_8px_0_#17120F]">
+        <div className="flex items-start justify-between gap-4">
+          <div className="min-w-0">
+            <p className="text-[10px] font-black tracking-[0.22em] uppercase text-white/80 mb-1">Staff Check-In</p>
+            <h1 className="font-display text-xl md:text-2xl uppercase tracking-tight leading-tight drop-shadow-[2px_2px_0_#17120F] truncate">{eventName}</h1>
+            <span className="brand-stamp font-brush mt-2 inline-block -rotate-2 rounded-xl px-3 py-0.5 text-sm tracking-[0.12em]">受付中</span>
+          </div>
+          <div className="hidden sm:block shrink-0">
+            <BrandSign compact />
+          </div>
+        </div>
 
         {/* Event selector (issue #77) */}
         {events.length > 0 && (
           <select
             value={selectedEvent}
             onChange={e => changeEvent(e.target.value)}
-            className="mt-3 w-full bg-white/10 border border-white/30 text-white text-xs font-bold rounded-xl px-3 py-2 outline-none appearance-none"
+            aria-label="Select event"
+            className="mt-3 w-full bg-white border-2 border-[#17120F] text-[#17120F] text-xs font-black rounded-xl px-3 py-2.5 outline-none appearance-none shadow-[3px_3px_0_#17120F]"
           >
             {events.map(ev => (
-              <option key={ev.event_name} value={ev.event_name} className="text-[#30364F]">
+              <option key={ev.event_name} value={ev.event_name}>
                 {formatEventLabel(ev)}
               </option>
             ))}
           </select>
         )}
 
-        <div className="flex gap-4 mt-3 items-center">
-          <div className="text-center">
-            <p className="text-2xl font-black">{checkedInCount}</p>
-            <p className="text-[9px] uppercase opacity-60 tracking-widest">Checked In</p>
+        <div className="grid grid-cols-3 gap-2 mt-3 md:mt-4 text-[#17120F]">
+          <div className="rounded-xl md:rounded-2xl border-2 border-[#17120F] bg-[#FFD51B] p-2 md:p-3 shadow-[3px_3px_0_#17120F]">
+            <p className="text-xl md:text-2xl font-black">{pendingCount}</p>
+            <p className="text-[9px] uppercase opacity-70 tracking-widest font-black">Pending</p>
           </div>
-          <div className="text-white/30 font-thin text-2xl">/</div>
-          <div className="text-center">
-            <p className="text-2xl font-black">{attendingCount}</p>
-            <p className="text-[9px] uppercase opacity-60 tracking-widest">Total</p>
+          <div className="rounded-xl md:rounded-2xl border-2 border-[#17120F] bg-white p-2 md:p-3 shadow-[3px_3px_0_#17120F]">
+            <p className="text-xl md:text-2xl font-black">{checkedInCount}</p>
+            <p className="text-[9px] uppercase opacity-70 tracking-widest font-black">In</p>
           </div>
+          <div className="rounded-xl md:rounded-2xl border-2 border-[#17120F] bg-[#17120F] p-2 md:p-3 text-white shadow-[3px_3px_0_#FFD51B]">
+            <p className="text-xl md:text-2xl font-black">{attendingCount}</p>
+            <p className="text-[9px] uppercase opacity-70 tracking-widest font-black">People</p>
+          </div>
+        </div>
+
+        <div className="flex items-center gap-3 mt-3 md:mt-4">
+          <p className="text-xs font-black text-white drop-shadow-[1px_1px_0_#17120F]">{checkedInCount} / {attendingCount} in · {waitlistCount} waitlist</p>
           <div className="flex-1" />
           <button
             onClick={scanning ? stopScanner : startScanner}
-            className={`px-4 py-2 rounded-xl font-black text-xs uppercase tracking-widest ${scanning ? 'bg-red-500 text-white' : 'bg-[#E1D9BC] text-[#30364F]'}`}
+            className={`min-h-[44px] px-4 py-2 rounded-xl font-black text-xs uppercase tracking-widest cursor-pointer ${scanning ? 'brand-action text-white' : 'brand-action-alt'}`}
           >
-            {scanning ? 'Stop' : '📷 Scan'}
+            {scanning ? 'Stop' : 'Scan'}
           </button>
         </div>
       </div>
 
-      <div className="p-4 space-y-4">
+      <div className="p-4 space-y-4 lg:p-6">
         {/* Scanner — div is always mounted so html5-qrcode can attach to it. */}
-        <div className={`bg-white rounded-2xl border border-gray-200 overflow-hidden ${!scanning && !scanResult ? 'hidden' : ''}`}>
+        <div className={`brand-card rounded-2xl overflow-hidden ${!scanning && !scanResult ? 'hidden' : ''}`}>
           <div id={scannerDivId} className={`w-full ${scanning ? '' : 'hidden'}`} />
           {!scanning && scanResult && (() => {
             const meta = SCAN_RESULT_META[scanResult.kind]
             return (
-              <div className={`p-6 text-center ${meta.ok ? 'bg-green-50' : 'bg-red-50'}`}>
-                <div className="text-4xl mb-2">{meta.icon}</div>
-                <p className={`font-black text-lg uppercase ${meta.ok ? 'text-green-700' : 'text-red-700'}`}>
+              <div
+                role={meta.ok ? 'status' : 'alert'}
+                aria-live={meta.ok ? 'polite' : 'assertive'}
+                className={`p-6 text-center ${meta.ok ? 'bg-green-50' : 'bg-red-50'}`}
+              >
+                <p className={`mx-auto mb-3 inline-flex h-12 min-w-12 items-center justify-center rounded-full border-2 border-[#17120F] px-4 text-sm font-black uppercase tracking-widest ${meta.ok ? 'bg-[#FFD51B] text-[#17120F]' : 'bg-[#E51F1F] text-white'}`}>
+                  {meta.badge}
+                </p>
+                <p className={`font-black text-lg uppercase ${meta.ok ? 'text-green-800' : 'text-red-800'}`}>
                   {meta.title}
                 </p>
-                <p className="font-bold text-sm mt-1 text-gray-600">{scanResult.name}</p>
+                <p className="font-bold text-sm mt-1 text-[#5B3428]">{scanResult.name}</p>
                 <button
                   onClick={startScanner}
-                  className="mt-4 bg-[#30364F] text-white font-black uppercase text-xs tracking-widest px-6 py-2 rounded-xl"
+                  className="brand-action mt-4 font-black uppercase text-xs tracking-widest px-6 py-2 rounded-xl"
                 >
                   Scan Next
                 </button>
@@ -423,25 +490,34 @@ export default function AdminPage() {
           })()}
         </div>
 
-        {/* Filters + Search */}
+        {/* Filters */}
         <div className="flex gap-2">
           {(['all', 'pending', 'checked'] as const).map(f => (
             <button
               key={f}
               onClick={() => changeFilter(f)}
-              className={`px-3 py-1.5 rounded-lg text-[10px] font-black uppercase tracking-widest ${filter === f ? 'bg-[#30364F] text-white' : 'bg-[#F0F0DB] text-[#30364F] border border-[#ACBAC4]'}`}
+              aria-pressed={filter === f}
+              className={`min-h-[44px] px-4 py-2 rounded-lg text-[10px] font-black uppercase tracking-widest cursor-pointer border-2 border-[#17120F] ${filter === f ? 'bg-[#17120F] text-white shadow-[3px_3px_0_#FFD51B]' : 'bg-[#FFF8D8] text-[#17120F] shadow-[3px_3px_0_rgba(23,18,15,0.25)]'}`}
             >
               {f}
             </button>
           ))}
         </div>
-        <input
-          type="search"
-          placeholder="Search name..."
-          value={search}
-          onChange={e => setSearch(e.target.value)}
-          className="w-full border-2 border-[#ACBAC4] rounded-xl px-4 py-2.5 text-sm font-bold bg-white text-[#30364F] outline-none focus:border-[#30364F]"
-        />
+
+        {/* Search */}
+        <div>
+          <label htmlFor="attendee-search" className="block text-[10px] font-black uppercase tracking-widest text-[#8B2D1F] mb-2">
+            Search attendee
+          </label>
+          <input
+            id="attendee-search"
+            type="search"
+            placeholder="Search name, drink, guest, #id, @handle..."
+            value={search}
+            onChange={e => setSearch(e.target.value)}
+            className="w-full border-2 border-[#17120F] rounded-xl px-4 py-3 text-sm font-bold bg-white text-[#17120F] outline-none focus:border-[#E51F1F] shadow-[3px_3px_0_rgba(23,18,15,0.25)]"
+          />
+        </div>
 
         {/* Attendee list */}
         <div className="space-y-2">
@@ -450,34 +526,35 @@ export default function AdminPage() {
             const isIn = !!checkins[a.user_id]
             const checkinTime = isIn ? new Date(checkins[a.user_id].checked_in_at).toLocaleTimeString('en-GB', { hour: '2-digit', minute: '2-digit' }) : null
             return (
-              <div key={a.user_id} className={`bg-white rounded-2xl border-2 overflow-hidden ${isIn ? 'border-green-300' : 'border-gray-200'}`}>
+              <div key={a.user_id} className={`rounded-2xl border-2 border-[#17120F] overflow-hidden shadow-[4px_4px_0_rgba(23,18,15,0.25)] ${isIn ? 'bg-green-50' : 'bg-white'}`}>
                 <div className="p-4 flex items-center gap-3">
-                  <div className={`w-10 h-10 rounded-full flex items-center justify-center font-black text-lg shrink-0 ${isIn ? 'bg-green-100 text-green-700' : 'bg-[#E1D9BC] text-[#30364F]'}`}>
+                  <div className={`w-10 h-10 rounded-full border-2 border-[#17120F] flex items-center justify-center font-black text-lg shrink-0 ${isIn ? 'bg-green-100 text-green-800' : 'bg-[#FFD51B] text-[#17120F]'}`}>
                     {isIn ? '✓' : name[0].toUpperCase()}
                   </div>
                   <div className="flex-1 min-w-0">
-                    <p className="font-black text-[#30364F] truncate">{name}</p>
+                    <p className="font-black text-[#17120F] truncate">{name}</p>
                     <div className="flex flex-wrap gap-1 mt-1">
                       {a.drinks.map((d, i) => (
-                        <span key={i} className="flex items-center gap-1 text-[9px] font-bold text-gray-500 uppercase tracking-wide">
+                        <span key={i} className="flex items-center gap-1 text-[9px] font-bold text-[#5B3428] uppercase tracking-wide">
                           <span className={`w-2 h-2 rounded-full shrink-0 ${drinkDot(d)}`} />
                           {d}
                         </span>
                       ))}
                     </div>
                     {a.extra_people > 0 && (
-                      <p className="text-[9px] text-gray-400 mt-0.5">+{a.extra_people} guest{a.extra_people > 1 ? 's' : ''}{a.extras_names.length > 0 ? `: ${a.extras_names.join(', ')}` : ''}</p>
+                      <p className="text-[9px] text-[#8B2D1F] mt-0.5">+{a.extra_people} guest{a.extra_people > 1 ? 's' : ''}{a.extras_names.length > 0 ? `: ${a.extras_names.join(', ')}` : ''}</p>
                     )}
+                    <p className="mt-1 text-[9px] font-bold uppercase tracking-widest text-[#8B2D1F]/60">@{a.username}</p>
                   </div>
                   <div className="flex items-center gap-2 shrink-0">
                     <div className="text-right min-w-[34px]">
                       {isIn ? (
                         <div>
-                          <span className="text-[9px] font-black text-green-600 uppercase tracking-widest">In</span>
-                          <p className="text-[9px] text-gray-400">{checkinTime}</p>
+                          <span className="text-[9px] font-black text-green-700 uppercase tracking-widest">In</span>
+                          <p className="text-[9px] text-[#8B2D1F]">{checkinTime}</p>
                         </div>
                       ) : (
-                        <span className="text-[9px] font-black text-gray-300 uppercase tracking-widest">Pending</span>
+                        <span className="text-[9px] font-black text-[#8B2D1F]/60 uppercase tracking-widest">Pending</span>
                       )}
                     </div>
                     {/* Manual check-in — always tappable; emphasised when active */}
@@ -485,7 +562,7 @@ export default function AdminPage() {
                       onClick={() => manualCheckin(a.user_id)}
                       aria-label={`Check in ${name}`}
                       title="Check in"
-                      className={`w-9 h-9 rounded-xl flex items-center justify-center shrink-0 active:scale-95 transition ${isIn ? 'bg-green-600 text-white' : 'bg-green-100 text-green-700 active:bg-green-200'}`}
+                      className={`w-11 h-11 rounded-xl border-2 border-[#17120F] flex items-center justify-center shrink-0 active:translate-x-[1px] active:translate-y-[1px] transition ${isIn ? 'bg-green-600 text-white' : 'bg-[#FFD51B] text-[#17120F]'}`}
                     >
                       <svg viewBox="0 0 24 24" className="w-5 h-5" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
                         <path d="M20 6 9 17l-5-5" />
@@ -496,7 +573,7 @@ export default function AdminPage() {
                       onClick={() => manualCheckout(a.user_id)}
                       aria-label={`Check out ${name}`}
                       title="Check out"
-                      className="w-9 h-9 rounded-xl flex items-center justify-center shrink-0 bg-red-100 text-red-700 active:bg-red-200 active:scale-95 transition"
+                      className="w-11 h-11 rounded-xl border-2 border-[#17120F] flex items-center justify-center shrink-0 bg-white text-[#E51F1F] active:translate-x-[1px] active:translate-y-[1px] transition"
                     >
                       <svg viewBox="0 0 24 24" className="w-5 h-5" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
                         <path d="M18 6 6 18M6 6l12 12" />
@@ -508,21 +585,21 @@ export default function AdminPage() {
             )
           })}
           {filtered.length === 0 && (
-            <p className="text-center text-sm text-gray-400 py-8">No attendees found</p>
+            <p className="text-center text-sm font-black text-[#8B2D1F] py-8">No attendees found</p>
           )}
         </div>
 
         {/* Waitlist section */}
         {attendees.some(a => a.status === 'waitlist') && filter === 'all' && !search && (
           <div className="mt-6">
-            <p className="text-[9px] font-black uppercase tracking-widest text-gray-400 mb-2">Waitlist</p>
+            <p className="text-[9px] font-black uppercase tracking-widest text-[#8B2D1F] mb-2">Waitlist</p>
             <div className="space-y-2">
               {attendees.filter(a => a.status === 'waitlist').map(a => (
-                <div key={a.user_id} className="bg-amber-50 rounded-2xl border border-amber-200 p-4 flex items-center gap-3">
-                  <div className="w-8 h-8 rounded-full bg-amber-100 flex items-center justify-center font-black text-amber-700 shrink-0">
+                <div key={a.user_id} className="bg-[#FFD51B] rounded-2xl border-2 border-[#17120F] p-4 flex items-center gap-3 shadow-[4px_4px_0_rgba(23,18,15,0.25)]">
+                  <div className="w-8 h-8 rounded-full border-2 border-[#17120F] bg-white flex items-center justify-center font-black text-[#17120F] shrink-0">
                     {(a.display_name || a.username)[0].toUpperCase()}
                   </div>
-                  <p className="font-bold text-amber-800 text-sm">{a.display_name || a.username}</p>
+                  <p className="font-bold text-[#17120F] text-sm">{a.display_name || a.username}</p>
                 </div>
               ))}
             </div>

--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -1,13 +1,18 @@
 @import "tailwindcss";
 
 :root {
-  --background: #E1D9BC;
-  --foreground: #30364F;
-  --card: #F0F0DB;
-  --accent: #ACBAC4;
+  --background: #FFF1C2;
+  --foreground: #23110D;
+  --card: #FFF8D8;
+  --accent: #E51F1F;
+  --brand-red: #E51F1F;
+  --brand-yellow: #FFD51B;
+  --brand-gold: #FFC400;
+  --brand-ink: #17120F;
+  --brand-cream: #FFF8D8;
 }
 
-theme inline {
+@theme inline {
   --color-background: var(--background);
   --color-foreground: var(--foreground);
   --color-card: var(--card);
@@ -19,6 +24,134 @@ body {
   background-color: var(--background);
   color: var(--foreground);
   -webkit-tap-highlight-color: transparent;
+  touch-action: manipulation;
+}
+
+button, a, input {
+  touch-action: manipulation;
+}
+
+.font-display {
+  font-family: var(--font-display), "Hiragino Kaku Gothic ProN", "Yu Gothic", var(--font-noto-sans), sans-serif;
+}
+
+.font-brush {
+  font-family: var(--font-brush), var(--font-display), "Hiragino Kaku Gothic ProN", "Yu Gothic", var(--font-noto-sans), sans-serif;
+}
+
+.brand-bg {
+  background-color: var(--background);
+  background-image:
+    radial-gradient(circle at 50% 0%, rgba(255, 213, 27, 0.28), rgba(255, 241, 194, 0) 42%),
+    radial-gradient(rgba(229, 31, 31, 0.1) 2px, transparent 2.5px),
+    radial-gradient(rgba(229, 31, 31, 0.1) 2px, transparent 2.5px);
+  background-size: 100% 460px, 26px 26px, 26px 26px;
+  background-position: 50% 0, 0 0, 13px 13px;
+  background-repeat: no-repeat, repeat, repeat;
+}
+
+.brand-rays {
+  background:
+    radial-gradient(circle at 50% 120%, rgba(255, 248, 216, 0.2) 0 18%, transparent 19%),
+    repeating-conic-gradient(from -18deg at 50% 115%, var(--brand-yellow) 0deg 7deg, var(--brand-red) 7deg 14deg);
+}
+
+.brand-sunburst {
+  background:
+    radial-gradient(circle at 50% 40%, rgba(255, 248, 216, 0.55) 0 5%, rgba(255, 213, 27, 0) 16%),
+    repeating-conic-gradient(from 7.5deg at 50% 40%, var(--brand-red) 0deg 15deg, var(--brand-yellow) 15deg 30deg);
+}
+
+.brand-wordmark {
+  font-family: var(--font-brush), var(--font-display), "Hiragino Kaku Gothic ProN", "Yu Gothic", sans-serif;
+  color: var(--brand-ink);
+  -webkit-text-stroke: 5px var(--brand-gold);
+  paint-order: stroke fill;
+  filter: drop-shadow(3px 3px 0 var(--brand-ink));
+  line-height: 1;
+}
+
+.brand-banner {
+  font-family: var(--font-brush), var(--font-display), "Hiragino Kaku Gothic ProN", sans-serif;
+  background: var(--brand-ink);
+  color: var(--brand-cream);
+  border: 2px solid var(--brand-ink);
+  box-shadow: 0 3px 0 rgba(23, 18, 15, 0.4);
+}
+
+.brand-hanko {
+  font-family: var(--font-brush), "Hiragino Kaku Gothic ProN", "Yu Gothic", sans-serif;
+  color: var(--brand-red);
+  border: 3px solid var(--brand-red);
+  background: rgba(255, 248, 216, 0.9);
+  border-radius: 9999px;
+  box-shadow: 2px 2px 0 rgba(23, 18, 15, 0.3);
+  writing-mode: vertical-rl;
+  letter-spacing: 0.08em;
+}
+
+.paper-grain::after {
+  content: "";
+  position: fixed;
+  inset: 0;
+  z-index: 1;
+  pointer-events: none;
+  opacity: 0.05;
+  mix-blend-mode: multiply;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='120' height='120'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='2'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)'/%3E%3C/svg%3E");
+}
+
+.brand-card {
+  background: var(--brand-cream);
+  border: 2px solid var(--brand-ink);
+  box-shadow: 5px 5px 0 var(--brand-ink);
+}
+
+.brand-ticket {
+  background:
+    linear-gradient(135deg, rgba(255, 213, 27, 0.26), rgba(255, 248, 216, 0.92) 36%, rgba(255, 255, 255, 0.95)),
+    var(--brand-cream);
+  border: 2px solid var(--brand-ink);
+  box-shadow: inset 0 0 0 2px rgba(229, 31, 31, 0.08);
+}
+
+.brand-seal {
+  background: var(--brand-ink);
+  border: 2px solid #fff;
+  box-shadow: 4px 4px 0 var(--brand-yellow);
+  font-family: "Hiragino Kaku Gothic ProN", "Yu Gothic", var(--font-noto-sans), sans-serif;
+}
+
+.brand-stamp {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border: 3px solid var(--brand-red);
+  color: var(--brand-red);
+  background: rgba(255, 248, 216, 0.92);
+  box-shadow: 3px 3px 0 var(--brand-ink);
+  font-family: "Hiragino Kaku Gothic ProN", "Yu Gothic", var(--font-noto-sans), sans-serif;
+  font-weight: 900;
+}
+
+.brand-action {
+  background: var(--brand-red);
+  color: #fff;
+  border: 2px solid var(--brand-ink);
+  box-shadow: 3px 3px 0 var(--brand-yellow);
+}
+
+.brand-action-alt {
+  background: var(--brand-yellow);
+  color: var(--brand-ink);
+  border: 2px solid var(--brand-ink);
+  box-shadow: 3px 3px 0 rgba(23, 18, 15, 0.35);
+}
+
+.brand-action:active,
+.brand-action-alt:active {
+  transform: translate(2px, 2px);
+  box-shadow: 1px 1px 0 var(--brand-ink);
 }
 
 .no-scrollbar::-webkit-scrollbar { display: none; }
@@ -30,8 +163,20 @@ body {
 }
 .animate-slide-up { animation: slideUp 0.3s ease-out forwards; }
 
+@keyframes lanternSway {
+  0%, 100% { transform: rotate(-5deg); }
+  50% { transform: rotate(5deg); }
+}
 input:focus, select:focus {
   outline: none;
-  border-color: #30364F;
-  box-shadow: 0 0 0 1px #30364F;
+  border-color: var(--brand-red);
+  box-shadow: 0 0 0 2px var(--brand-red);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *, *::before, *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+  }
 }

--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -1,5 +1,5 @@
 import type { Metadata, Viewport } from "next";
-import { Noto_Sans } from "next/font/google";
+import { Noto_Sans, Dela_Gothic_One, Reggae_One } from "next/font/google";
 import "./globals.css";
 
 const notoSans = Noto_Sans({
@@ -8,24 +8,36 @@ const notoSans = Noto_Sans({
   variable: "--font-noto-sans",
 });
 
+const delaGothic = Dela_Gothic_One({
+  subsets: ["latin"],
+  weight: "400",
+  variable: "--font-display",
+  display: "swap",
+});
+
+const reggaeOne = Reggae_One({
+  subsets: ["latin"],
+  weight: "400",
+  variable: "--font-brush",
+  display: "swap",
+});
+
 export const metadata: Metadata = {
-  title: "chibachan",
-  description: "offkai rsvp",
+  title: "Offkai Bot",
+  description: "Offkai RSVP & door check-in",
   manifest: "/manifest.webmanifest",
 };
 
 export const viewport: Viewport = {
-  themeColor: "#30364F",
+  themeColor: "#E51F1F",
   width: "device-width",
   initialScale: 1,
-  maximumScale: 1,
-  userScalable: false,
 };
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
-    <html lang="en" className={notoSans.variable}>
-      <body className={`${notoSans.className} antialiased bg-[#E1D9BC] text-[#30364F]`}>
+    <html lang="en" className={`${notoSans.variable} ${delaGothic.variable} ${reggaeOne.variable}`}>
+      <body className={`${notoSans.className} brand-bg paper-grain antialiased text-[#23110D]`}>
         {children}
       </body>
     </html>

--- a/frontend/app/manifest.ts
+++ b/frontend/app/manifest.ts
@@ -2,13 +2,13 @@ import type { MetadataRoute } from 'next'
 
 export default function manifest(): MetadataRoute.Manifest {
   return {
-    name: 'chibachan',
-    short_name: 'chibachan',
-    description: 'Offkai RSVP frontend',
+    name: 'Offkai Bot',
+    short_name: 'Offkai',
+    description: 'Offkai RSVP & door check-in',
     start_url: '/',
     display: 'standalone',
-    background_color: '#E1D9BC',
-    theme_color: '#30364F',
+    background_color: '#FFF1C2',
+    theme_color: '#E51F1F',
     icons: [
       {
         src: '/icon.svg',

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -3,7 +3,7 @@ import { useState, useEffect, Suspense } from 'react'
 import { useSearchParams } from 'next/navigation'
 import QRCode from 'react-qr-code'
 
-type ViewState = 'loading' | 'no_token' | 'invalid' | 'not_found' | 'ready'
+type ViewState = 'loading' | 'no_token' | 'invalid' | 'not_found' | 'unavailable' | 'ready'
 type AttendeeData = { attendee: Record<string, unknown>; event: Record<string, unknown> }
 
 function getDrinkColors(name: string) {
@@ -14,58 +14,221 @@ function getDrinkColors(name: string) {
   if (n.includes('sapporo') || n.includes('beer')) return { bg: 'bg-amber-50', border: 'border-amber-200', strip: 'bg-amber-400' }
   if (n.includes('highball'))    return { bg: 'bg-orange-50',  border: 'border-orange-200', strip: 'bg-orange-600' }
   if (n.includes('lemon'))       return { bg: 'bg-yellow-50',  border: 'border-yellow-200', strip: 'bg-yellow-400' }
-  return { bg: 'bg-gray-50', border: 'border-gray-200', strip: 'bg-[#30364F]' }
+  return { bg: 'bg-white', border: 'border-[#17120F]', strip: 'bg-[#17120F]' }
 }
 
-function formatDateJST(iso: string) {
+function formatArrivalTime(iso: string) {
+  if (!iso) return 'TBD'
   try {
-    return new Date(iso).toLocaleString('en-GB', {
-      timeZone: 'Asia/Tokyo',
-      weekday: 'long', year: 'numeric', month: 'long', day: 'numeric',
-      hour: '2-digit', minute: '2-digit',
+    return new Date(iso).toLocaleTimeString('en-GB', {
+      timeZone: 'Asia/Tokyo', hour: '2-digit', minute: '2-digit',
     }) + ' JST'
-  } catch { return iso }
+  } catch { return 'TBD' }
+}
+
+function getEventPhase(iso: string) {
+  if (!iso) return 'Date pending'
+  const eventTime = new Date(iso).getTime()
+  if (Number.isNaN(eventTime)) return 'Date pending'
+  const diffMinutes = Math.round((eventTime - Date.now()) / 60000)
+  if (diffMinutes > 90) return `Starts ${new Date(iso).toLocaleDateString('en-GB', { timeZone: 'Asia/Tokyo', month: 'short', day: 'numeric' })}`
+  if (diffMinutes > 0) return `Starts in ${diffMinutes} min`
+  if (diffMinutes > -180) return 'Happening now'
+  return 'Event ended'
 }
 
 function DrinkCard({ name }: { name: string }) {
   const c = getDrinkColors(name)
   return (
-    <div className={`${c.bg} rounded-xl border-2 ${c.border} px-4 py-3 relative overflow-hidden flex items-center gap-3`}>
+    <div className={`${c.bg} rounded-xl border-2 ${c.border} px-4 py-3 relative overflow-hidden flex items-center gap-3 shadow-[3px_3px_0_#17120F]`}>
       <div className={`absolute left-0 top-0 bottom-0 w-2 ${c.strip}`} />
-      <span className="font-black text-[#30364F] text-sm pl-2">{name}</span>
+      <span className="font-black text-[#23110D] text-sm pl-2">{name}</span>
     </div>
+  )
+}
+
+function Lantern({ className = '', delay = '0s', variant = 'red', glyph = '祭' }: { className?: string; delay?: string; variant?: 'red' | 'gold'; glyph?: string }) {
+  const body = variant === 'gold' ? '#FFC400' : '#E51F1F'
+  const glyphFill = variant === 'gold' ? '#9A1414' : '#FFF8D8'
+  return (
+    <svg
+      viewBox="0 0 44 74"
+      className={className}
+      style={{ transformOrigin: 'top center', animation: 'lanternSway 3.4s ease-in-out infinite', animationDelay: delay }}
+      aria-hidden="true"
+    >
+      <line x1="22" y1="0" x2="22" y2="8" stroke="#17120F" strokeWidth="2" />
+      <rect x="11" y="7" width="22" height="7" rx="2.5" fill="#3A2A1A" stroke="#17120F" strokeWidth="2" />
+      <ellipse cx="22" cy="35" rx="18" ry="21" fill={body} stroke="#17120F" strokeWidth="2.5" />
+      <ellipse cx="15" cy="29" rx="4" ry="8" fill="#FFFFFF" opacity="0.22" />
+      <g stroke="#17120F" strokeOpacity="0.32" strokeWidth="1.5" fill="none">
+        <path d="M5.5 27 Q22 24 38.5 27" />
+        <path d="M4 35 Q22 32 40 35" />
+        <path d="M5.5 43 Q22 46 38.5 43" />
+      </g>
+      <text x="22" y="41" textAnchor="middle" fontSize="18" fontWeight="700" fill={glyphFill} style={{ fontFamily: "'Hiragino Kaku Gothic ProN','Yu Gothic',sans-serif" }}>{glyph}</text>
+      <rect x="14" y="54" width="16" height="6" rx="2" fill="#3A2A1A" stroke="#17120F" strokeWidth="2" />
+      <g stroke="#FFC400" strokeWidth="2" strokeLinecap="round">
+        <line x1="18" y1="60" x2="17" y2="71" /><line x1="22" y1="60" x2="22" y2="72" /><line x1="26" y1="60" x2="27" y2="71" />
+      </g>
+    </svg>
+  )
+}
+
+function LanternGarland() {
+  const lanterns = [
+    { g: '大', v: 'red' }, { g: '衆', v: 'gold' }, { g: '酒', v: 'red' }, { g: '場', v: 'gold' },
+    { g: '乾', v: 'red' }, { g: '杯', v: 'gold' }, { g: '祭', v: 'red' },
+  ] as const
+  return (
+    <div className="pointer-events-none absolute inset-x-0 top-0 px-1.5" aria-hidden="true">
+      <div className="absolute left-2 right-2 top-1.5 h-0.5 rounded-full bg-[#17120F]/70" />
+      <div className="relative flex items-start justify-between">
+        {lanterns.map((l, i) => (
+          <Lantern key={i} variant={l.v} glyph={l.g} delay={`${i * 0.22}s`} className={i % 2 ? 'h-9' : 'h-[2.9rem]'} />
+        ))}
+      </div>
+    </div>
+  )
+}
+
+function KaraagePiece({ x, y, s = 1, rot = 0 }: { x: number; y: number; s?: number; rot?: number }) {
+  return (
+    <g transform={`translate(${x} ${y}) rotate(${rot}) scale(${s})`}>
+      <path
+        d="M0 -13 C5 -13 7 -10 9 -9 C13 -9 14 -5 13 -2 C15 2 13 6 10 7 C9 11 5 13 1 11 C-3 13 -8 11 -8 7 C-12 6 -13 1 -11 -3 C-13 -7 -9 -11 -5 -10 C-4 -12 -2 -13 0 -13 Z"
+        fill="#C36A18" stroke="#17120F" strokeWidth="2.2" strokeLinejoin="round"
+      />
+      <path d="M-5 -6 C-1 -8 4 -7 5 -3 C6 0 3 3 -1 2 C-5 2 -7 -3 -5 -6 Z" fill="#E89A40" />
+      <circle cx="4" cy="5" r="1.2" fill="#3A2410" />
+      <circle cx="-3" cy="6" r="1" fill="#3A2410" />
+      <circle cx="6" cy="-2" r="0.9" fill="#3A2410" />
+    </g>
+  )
+}
+
+function KaraageBoat({ className = '' }: { className?: string }) {
+  const pieces = [
+    { x: 46, y: 98, s: 1, rot: -8 }, { x: 72, y: 104, s: 1.1, rot: 12 }, { x: 102, y: 106, s: 1.18, rot: -4 },
+    { x: 134, y: 104, s: 1.1, rot: 14 }, { x: 162, y: 98, s: 1, rot: -10 },
+    { x: 60, y: 84, s: 1, rot: 18 }, { x: 90, y: 86, s: 1.05, rot: -14 }, { x: 120, y: 86, s: 1.05, rot: 8 }, { x: 150, y: 84, s: 1, rot: -18 },
+    { x: 78, y: 68, s: 0.95, rot: -6 }, { x: 108, y: 68, s: 1, rot: 12 }, { x: 136, y: 68, s: 0.95, rot: -12 },
+    { x: 94, y: 56, s: 0.92, rot: 8 }, { x: 122, y: 56, s: 0.92, rot: -8 }, { x: 108, y: 46, s: 0.85, rot: 2 },
+  ]
+  const negi = [
+    { x: 72, y: 40 }, { x: 80, y: 24 }, { x: 86, y: 14 }, { x: 92, y: 8 }, { x: 98, y: 4, green: true }, { x: 103, y: 12 },
+    { x: 108, y: 2 }, { x: 113, y: 8, green: true }, { x: 118, y: 0 }, { x: 123, y: 8 }, { x: 128, y: 2 },
+    { x: 133, y: 10, green: true }, { x: 138, y: 4 }, { x: 144, y: 14 }, { x: 150, y: 22, green: true }, { x: 158, y: 36 },
+    { x: 100, y: 16 }, { x: 114, y: 14 }, { x: 128, y: 18 }, { x: 66, y: 30 },
+  ]
+  return (
+    <svg viewBox="0 0 240 168" className={className} aria-hidden="true">
+      <g stroke="#FFFFFF" strokeWidth="3" strokeLinecap="round" fill="none" opacity="0.6">
+        <path d="M84 14 q-7 -9 0 -17 q5 -6 0 -12" /><path d="M120 8 q-7 -9 0 -17 q5 -6 0 -12" /><path d="M156 16 q-7 -9 0 -17 q5 -6 0 -12" />
+      </g>
+      <g strokeLinecap="round" strokeWidth="3.6">
+        {negi.map((n, i) => (
+          <line key={i} x1="115" y1="56" x2={n.x} y2={n.y} stroke={n.green ? '#7FB84A' : '#FCFCF7'} />
+        ))}
+      </g>
+      <path d="M88 54 Q104 40 120 44 Q138 39 152 54 Q138 62 120 60 Q100 63 88 54 Z" fill="#FCFCF7" stroke="#17120F" strokeWidth="1.6" strokeLinejoin="round" />
+      {pieces.map((p, i) => <KaraagePiece key={i} {...p} />)}
+      <g stroke="#17120F" strokeWidth="2" strokeLinejoin="round">
+        <path d="M40 102 a15 15 0 0 1 15 15 l-15 0 z" fill="#FFE34D" />
+        <path d="M40 102 a15 15 0 0 1 15 15" fill="none" stroke="#E8C200" strokeWidth="2" />
+        <path d="M196 102 a15 15 0 0 0 -15 15 l15 0 z" fill="#FFE34D" />
+      </g>
+      <path d="M6 108 Q120 99 234 108 L210 130 Q120 152 30 130 Z" fill="#A9743C" stroke="#17120F" strokeWidth="2.6" strokeLinejoin="round" />
+      <path d="M6 108 Q120 99 234 108 L228 113 Q120 105 12 113 Z" fill="#C28E50" stroke="#17120F" strokeWidth="1.5" />
+      <path d="M26 118 Q120 130 214 118" fill="none" stroke="#6B4521" strokeWidth="2.4" strokeLinecap="round" />
+      <g stroke="#6B4521" strokeWidth="1.4" strokeOpacity="0.55" strokeLinecap="round">
+        <line x1="60" y1="124" x2="60" y2="134" /><line x1="100" y1="128" x2="100" y2="139" />
+        <line x1="140" y1="128" x2="140" y2="139" /><line x1="180" y1="124" x2="180" y2="134" />
+      </g>
+    </svg>
+  )
+}
+
+function SmileyMark({ className = '' }: { className?: string }) {
+  return (
+    <svg viewBox="0 0 40 40" className={className} aria-hidden="true">
+      <circle cx="20" cy="20" r="18" fill="#E51F1F" stroke="#17120F" strokeWidth="2.5" />
+      <circle cx="13" cy="16.5" r="2.6" fill="#17120F" />
+      <circle cx="27" cy="16.5" r="2.6" fill="#17120F" />
+      <path d="M11 22 q9 11 18 0" fill="none" stroke="#17120F" strokeWidth="3" strokeLinecap="round" />
+    </svg>
+  )
+}
+
+function BrandSign({ compact = false }: { compact?: boolean }) {
+  if (compact) {
+    return (
+      <div className="inline-flex items-center gap-1.5">
+        <SmileyMark className="h-7 w-7 shrink-0 -rotate-6" />
+        <span className="brand-wordmark text-2xl leading-none">Offkai Bot</span>
+      </div>
+    )
+  }
+  return (
+    <div className="inline-flex flex-col items-center px-2">
+      <span className="brand-banner inline-block rounded-lg px-3 py-0.5 text-[11px] tracking-[0.34em]">大衆酒場</span>
+      <div className="mt-2 flex items-center gap-1.5">
+        <span className="brand-wordmark text-[2.4rem] leading-[0.95]">Offkai Bot</span>
+        <SmileyMark className="h-8 w-8 shrink-0 -rotate-6 drop-shadow-[2px_2px_0_#17120F]" />
+      </div>
+      <span className="mt-2 font-display text-[10px] uppercase tracking-[0.42em] text-white drop-shadow-[1.5px_1.5px_0_#17120F]">RSVP Pass</span>
+    </div>
+  )
+}
+
+function CenterCard({ children }: { children: React.ReactNode }) {
+  return (
+    <main className="brand-rays min-h-dvh flex items-center justify-center p-6 text-[#23110D]">
+      <div className="brand-card w-full max-w-sm rounded-3xl p-7 text-center">
+        {children}
+      </div>
+    </main>
   )
 }
 
 function NoToken() {
   return (
-    <main className="min-h-screen bg-[#E1D9BC] flex items-center justify-center p-6 text-[#30364F]">
-      <div className="bg-[#F0F0DB] p-8 rounded-3xl border border-[#ACBAC4] shadow-xl w-full max-w-sm text-center">
-        <div className="text-5xl mb-6">💬</div>
-        <h1 className="text-lg font-black uppercase tracking-widest mb-3">Check Your DMs</h1>
-        <p className="text-sm opacity-60 leading-relaxed">
-          Your personal event link was sent to you via Discord DM. Open that message and tap the link to view your RSVP details.
-        </p>
-      </div>
-    </main>
+    <CenterCard>
+      <BrandSign compact />
+      <h1 className="mt-7 font-display text-2xl uppercase tracking-tight">Check Your DMs</h1>
+      <p className="mt-3 text-sm font-bold leading-relaxed text-[#5B3428]">
+        Your personal event link was sent to you via Discord DM. Open that message and tap the link to view your RSVP details.
+      </p>
+    </CenterCard>
   )
 }
 
-function InvalidToken({ reason }: { reason: 'invalid' | 'not_found' }) {
+function InvalidToken({ reason }: { reason: 'invalid' | 'not_found' | 'unavailable' }) {
+  const title = reason === 'not_found' ? 'RSVP Not Found' : reason === 'unavailable' ? 'RSVP Unavailable' : 'Link Invalid'
+  const badge = reason === 'not_found' ? '404' : reason === 'unavailable' ? '503' : 'NG'
+  const message =
+    reason === 'not_found'
+      ? "We couldn't find your RSVP for this event. Check with the event host if you believe this is an error."
+      : reason === 'unavailable'
+        ? "We couldn't load your RSVP right now. Check your connection and try again."
+        : 'This link has expired or is invalid. Check your Discord DMs for an updated link.'
   return (
-    <main className="min-h-screen bg-[#E1D9BC] flex items-center justify-center p-6 text-[#30364F]">
-      <div className="bg-[#F0F0DB] p-8 rounded-3xl border-2 border-red-300 shadow-xl w-full max-w-sm text-center">
-        <div className="text-5xl mb-6">{reason === 'not_found' ? '🔍' : '⚠️'}</div>
-        <h1 className="text-lg font-black uppercase tracking-widest mb-3">
-          {reason === 'not_found' ? 'RSVP Not Found' : 'Link Invalid'}
-        </h1>
-        <p className="text-sm opacity-60 leading-relaxed">
-          {reason === 'not_found'
-            ? 'We couldn\'t find your RSVP for this event. Check with the event host if you believe this is an error.'
-            : 'This link has expired or is invalid. Check your Discord DMs for an updated link.'}
-        </p>
-      </div>
-    </main>
+    <CenterCard>
+      <BrandSign compact />
+      <p className="mx-auto mt-7 inline-flex h-12 min-w-12 items-center justify-center rounded-full border-2 border-[#17120F] bg-[#E51F1F] px-4 text-sm font-black uppercase tracking-widest text-white">
+        {badge}
+      </p>
+      <h1 className="mt-4 font-display text-2xl uppercase tracking-tight">{title}</h1>
+      <p className="mt-3 text-sm font-bold leading-relaxed text-[#5B3428]">{message}</p>
+      {reason === 'unavailable' && (
+        <button
+          onClick={() => window.location.reload()}
+          className="brand-action mt-5 min-h-[44px] rounded-xl px-6 font-black uppercase tracking-widest text-sm"
+        >
+          Retry
+        </button>
+      )}
+    </CenterCard>
   )
 }
 
@@ -76,99 +239,155 @@ function RSVPCard({ data, token }: { data: AttendeeData; token: string }) {
   const drinks = (attendee.drinks as string[]) ?? []
   const extraPeople = (attendee.extra_people as number) ?? 0
   const extrasNames = (attendee.extras_names as string[]) ?? []
+  const behaviorConfirmed = !!attendee.behavior_confirmed
+  const arrivalConfirmed = !!attendee.arrival_confirmed
   const eventName = event.event_name as string
-  const venue = event.venue as string
-  const address = event.address as string
-  const mapsLink = event.google_maps_link as string
-  const datetime = event.event_datetime as string
+  const venue = (event.venue as string) || 'TBA'
+  const address = (event.address as string) || ''
+  const mapsLink = (event.google_maps_link as string) || ''
+  const datetime = (event.event_datetime as string) || ''
+  const maxCapacity = event.max_capacity as number | undefined
+  const eventOpen = event.open as boolean | undefined
+  const eventDeadline = event.event_deadline as string | undefined
   const isWaitlist = status === 'waitlist'
+  const partySize = 1 + extraPeople
+  const companions = extrasNames.length > 0 ? extrasNames.join(', ') : extraPeople > 0 ? `+${extraPeople} guest${extraPeople > 1 ? 's' : ''}` : 'Solo'
+  const rsvpStatus = typeof eventOpen === 'boolean' ? (eventOpen ? 'Open' : 'Closed') : 'TBD'
+  const checks = [
+    { label: 'Entry pass', done: !isWaitlist },
+    { label: 'Rules', done: behaviorConfirmed },
+    { label: 'Arrival', done: arrivalConfirmed },
+  ]
   const qrValue = typeof window !== 'undefined'
     ? `${window.location.origin}/?token=${token}`
-    : `https://chibachan.fadekyun.com/?token=${token}`
+    : `/?token=${token}`
 
   return (
-    <main className="min-h-screen bg-[#E1D9BC] text-[#30364F] pb-12 font-sans">
-      {/* Header */}
-      <div className="bg-[#30364F] text-white p-6 rounded-b-3xl shadow-xl">
-        <p className="text-[10px] font-black tracking-[0.2em] uppercase opacity-60 mb-1">Your RSVP</p>
-        <h1 className="text-xl font-black uppercase tracking-tight leading-tight">{eventName}</h1>
-        <p className="text-xs opacity-50 mt-1">{formatDateJST(datetime)}</p>
+    <main className="brand-bg min-h-dvh w-full max-w-md mx-auto text-[#23110D] pb-12 font-sans md:my-8 md:min-h-0 md:rounded-[2rem] md:shadow-2xl md:overflow-hidden">
+      <div className="brand-sunburst relative overflow-hidden px-5 pb-5 pt-16 text-white rounded-b-[2rem] border-b-4 border-[#17120F] shadow-[0_8px_0_#17120F]">
+        <LanternGarland />
+
+        <div className="flex justify-center">
+          <BrandSign />
+        </div>
+
+        <div className="relative mt-1 flex justify-center">
+          <KaraageBoat className="h-36 w-auto drop-shadow-[3px_4px_0_rgba(23,18,15,0.22)]" />
+          <span className="brand-stamp font-brush absolute -left-1 bottom-3 -rotate-6 rounded-xl px-3 py-1 text-sm tracking-[0.12em]">バカ盛り</span>
+        </div>
+
+        <div className="mt-3 flex flex-col items-center text-center">
+          <div className="brand-banner inline-block rounded-xl px-4 py-1.5">
+            <h1 className="font-display text-lg sm:text-xl uppercase tracking-tight leading-tight text-[#FFF8D8]">{eventName}</h1>
+          </div>
+          <span className="mt-2 inline-block rounded-xl border-2 border-[#17120F] bg-white px-3 py-1 text-[10px] font-black uppercase tracking-widest text-[#17120F] shadow-[3px_3px_0_#FFD51B]">Offkai Pass</span>
+        </div>
+
+        <div className="mt-5 grid grid-cols-2 gap-2 text-[#23110D]">
+          <div className="rounded-2xl border-2 border-[#17120F] bg-[#FFD51B] p-3 shadow-[3px_3px_0_#17120F]">
+            <p className="text-[9px] font-black uppercase tracking-widest opacity-70">Today</p>
+            <p className="text-sm font-black">{getEventPhase(datetime)}</p>
+          </div>
+          <div className="rounded-2xl border-2 border-[#17120F] bg-white p-3 shadow-[3px_3px_0_#17120F]">
+            <p className="text-[9px] font-black uppercase tracking-widest opacity-70">Arrival</p>
+            <p className="text-sm font-black">{formatArrivalTime(datetime)}</p>
+          </div>
+        </div>
       </div>
 
       <div className="p-6 space-y-4">
-        {/* Main identity card */}
-        <div className="bg-white rounded-2xl shadow-xl overflow-hidden border border-gray-200">
-          <div className={`p-3 flex justify-between items-center ${isWaitlist ? 'bg-gradient-to-r from-amber-500 to-amber-400' : 'bg-gradient-to-r from-[#30364F] to-[#4a5578]'}`}>
-            <span className="text-[10px] font-black text-white/80 tracking-[0.2em] uppercase">RSVP Status</span>
-            <span className={`text-[9px] font-black px-3 py-1 rounded shadow uppercase tracking-widest border ${isWaitlist ? 'bg-white text-amber-700 border-amber-200' : 'bg-[#E1D9BC] text-[#30364F] border-[#30364F]'}`}>
-              {isWaitlist ? 'Waitlist' : 'Attending ✓'}
+        <div className="brand-card rounded-2xl overflow-hidden">
+          <div className={`${isWaitlist ? 'bg-[#F59E0B]' : 'bg-[#17120F]'} p-3 flex justify-between items-center`}>
+            <span className="text-[10px] font-black text-white tracking-[0.22em] uppercase">Entry Pass · 乾杯</span>
+            <span className={`text-[9px] font-black px-3 py-1 rounded border-2 uppercase tracking-widest ${isWaitlist ? 'bg-white text-[#17120F] border-[#17120F]' : 'bg-[#FFD51B] text-[#17120F] border-white'}`}>
+              {isWaitlist ? 'Waitlist' : 'Confirmed'}
             </span>
           </div>
-          <div className="p-6">
-            <p className="text-[9px] uppercase font-bold text-gray-400 tracking-wider mb-1">Name</p>
-            <h2 className="text-4xl font-black text-[#30364F] uppercase tracking-tighter leading-none mb-6">{name}</h2>
+          <div className="p-6 space-y-5">
+            <div>
+              <p className="text-[9px] uppercase font-black text-[#8B2D1F] tracking-[0.2em] mb-1">Name</p>
+              <h2 className="text-4xl font-black text-[#17120F] uppercase tracking-tight leading-none">{name}</h2>
+              <p className="mt-2 text-xs font-black text-[#8B2D1F]">Party of {partySize} · {companions}</p>
+            </div>
 
-            {extraPeople > 0 && (
-              <div className="border-t-2 border-dashed border-gray-200 pt-4">
-                <p className="text-[9px] uppercase font-bold text-gray-400 tracking-wider mb-2">
-                  +{extraPeople} Guest{extraPeople > 1 ? 's' : ''}
-                </p>
-                <div className="flex flex-wrap gap-2">
-                  {extrasNames.length > 0
-                    ? extrasNames.map((n, i) => (
-                        <span key={i} className="bg-[#E1D9BC] text-[#30364F] text-xs font-bold px-3 py-1 rounded-full">{n}</span>
-                      ))
-                    : <span className="text-xs text-gray-400 italic">Names TBD</span>}
+            {!isWaitlist ? (
+              <div className="brand-ticket relative rounded-2xl p-4 flex flex-col items-center gap-3">
+                <div className="brand-hanko absolute -right-2 -top-2 flex items-center justify-center px-1.5 py-2 text-[12px] rotate-6" aria-hidden="true">乾杯</div>
+                <div className="p-3 bg-white rounded-xl border-2 border-[#17120F] shadow-[4px_4px_0_#E51F1F]">
+                  <QRCode value={qrValue} size={188} fgColor="#17120F" role="img" aria-label={`Entry QR code for ${name}`} />
                 </div>
+                <p className="text-[9px] font-black uppercase tracking-[0.22em] text-[#8B2D1F]">Show at check-in</p>
+              </div>
+            ) : (
+              <div className="rounded-2xl border-2 border-[#17120F] bg-[#FFD51B] p-4 shadow-[4px_4px_0_#17120F]">
+                <p className="font-black uppercase tracking-widest text-[#17120F] text-sm">Standby Mode</p>
+                <p className="mt-1 text-xs font-bold text-[#5B3428]">You&apos;re on the waitlist — we&apos;ll DM you on Discord if a spot opens up.</p>
               </div>
             )}
           </div>
         </div>
 
-        {/* Drinks */}
+        <div className="brand-card rounded-2xl p-5">
+          <div className="flex items-start justify-between gap-3">
+            <div>
+              <p className="text-[9px] uppercase font-black text-[#8B2D1F] tracking-widest mb-3">Venue</p>
+              <p className="font-black text-[#17120F] text-lg leading-tight">{venue}</p>
+              {address && <p className="text-xs font-bold text-[#5B3428] mt-1">{address}</p>}
+            </div>
+            {mapsLink && (
+              <a href={mapsLink} target="_blank" rel="noopener noreferrer"
+                className="brand-action min-h-[44px] shrink-0 inline-flex items-center gap-1 text-[10px] font-black px-4 py-2 rounded-xl uppercase tracking-wider">
+                Maps
+              </a>
+            )}
+          </div>
+        </div>
+
         {drinks.length > 0 && (
-          <div className="bg-[#F0F0DB] rounded-2xl border border-[#ACBAC4] p-5">
-            <p className="text-[9px] uppercase font-bold text-gray-500 tracking-widest mb-3">
-              {drinks.length > 1 ? 'Drink Selections' : 'First Drink'}
-            </p>
+          <div className="brand-card rounded-2xl p-5">
+            <div className="mb-3 flex items-center justify-between gap-3">
+              <p className="text-[9px] uppercase font-black text-[#8B2D1F] tracking-widest">
+                {drinks.length > 1 ? 'Drink Tickets' : 'First Drink Ticket'}
+              </p>
+              <span className="brand-stamp font-brush rotate-2 rounded-lg px-2 py-0.5 text-[10px] tracking-[0.12em]">乾杯</span>
+            </div>
             <div className="space-y-2">
               {drinks.map((d, i) => <DrinkCard key={i} name={d} />)}
             </div>
           </div>
         )}
 
-        {/* Venue */}
-        <div className="bg-[#F0F0DB] rounded-2xl border border-[#ACBAC4] p-5">
-          <p className="text-[9px] uppercase font-bold text-gray-500 tracking-widest mb-3">Venue</p>
-          <p className="font-black text-[#30364F] text-lg leading-tight">{venue || 'TBA'}</p>
-          {address && <p className="text-xs text-gray-500 mt-1">{address}</p>}
-          {mapsLink && (
-            <a href={mapsLink} target="_blank" rel="noopener noreferrer"
-              className="mt-3 inline-flex items-center gap-1 text-[10px] font-bold text-white bg-[#30364F] px-3 py-2 rounded-lg uppercase tracking-wider">
-              📍 Open in Maps
-            </a>
-          )}
+        <div className="brand-card rounded-2xl p-5">
+          <p className="text-[9px] uppercase font-black text-[#8B2D1F] tracking-widest mb-3">Ready Check</p>
+          <div className="grid grid-cols-3 gap-2">
+            {checks.map(check => (
+              <div key={check.label} className={`rounded-xl border-2 p-3 text-center ${check.done ? 'bg-white border-[#17120F]' : 'bg-[#FFD51B] border-[#17120F]'}`}>
+                <p className="text-lg font-black">{check.done ? '✓' : '!'}</p>
+                <p className={`text-[9px] font-black uppercase tracking-widest ${check.done ? 'text-[#17120F]' : 'text-[#8B2D1F]'}`}>{check.label}</p>
+              </div>
+            ))}
+          </div>
         </div>
 
-        {isWaitlist && (
-          <div className="bg-amber-50 border-2 border-amber-200 rounded-2xl p-5 text-center">
-            <p className="text-amber-800 font-bold text-sm">You&apos;re on the waitlist</p>
-            <p className="text-amber-700 text-xs mt-1 opacity-70">You&apos;ll be notified via Discord if a spot opens up.</p>
-          </div>
-        )}
-
-        {/* QR Code */}
-        {!isWaitlist && (
-          <div className="bg-white rounded-2xl border border-gray-200 p-6 flex flex-col items-center gap-3">
-            <p className="text-[9px] uppercase font-bold text-gray-400 tracking-widest">Entry QR Code</p>
-            <div className="p-3 bg-white rounded-xl border border-gray-100">
-              <QRCode value={qrValue} size={180} fgColor="#30364F" />
+        <div className="brand-card rounded-2xl p-5">
+          <p className="text-[9px] uppercase font-black text-[#8B2D1F] tracking-widest mb-3">Offkai Details</p>
+          <div className="grid grid-cols-3 gap-2 text-center">
+            <div>
+              <p className="text-lg font-black text-[#17120F]">{maxCapacity || 'TBD'}</p>
+              <p className="text-[9px] font-black uppercase tracking-widest text-[#8B2D1F]">Capacity</p>
             </div>
-            <p className="text-[9px] text-gray-400 text-center">Show this at the door to check in</p>
+            <div>
+              <p className="text-lg font-black text-[#17120F]">{rsvpStatus}</p>
+              <p className="text-[9px] font-black uppercase tracking-widest text-[#8B2D1F]">RSVP</p>
+            </div>
+            <div>
+              <p className="text-lg font-black text-[#17120F]">{eventDeadline ? formatArrivalTime(eventDeadline) : 'TBD'}</p>
+              <p className="text-[9px] font-black uppercase tracking-widest text-[#8B2D1F]">Deadline</p>
+            </div>
           </div>
-        )}
+        </div>
 
-        <p className="text-center text-[9px] text-gray-400 uppercase tracking-widest pt-2">
+        <p className="text-center text-[10px] font-black text-[#8B2D1F] uppercase tracking-widest pt-2">
           This link is personal — please don&apos;t share it.
         </p>
       </div>
@@ -184,8 +403,6 @@ function AttendeeView() {
 
   useEffect(() => {
     if (!token) {
-      // Token is absent — schedule the state update asynchronously to avoid a
-      // synchronous setState call inside the effect body.
       const id = setTimeout(() => setView('no_token'), 0)
       return () => clearTimeout(id)
     }
@@ -195,19 +412,21 @@ function AttendeeView() {
       .then(({ ok, status, body }) => {
         if (ok) { setData(body); setView('ready') }
         else if (status === 404) setView('not_found')
+        else if (status >= 500) setView('unavailable')
         else setView('invalid')
       })
-      .catch(() => setView('invalid'))
+      .catch(() => setView('unavailable'))
   }, [token])
 
   if (view === 'loading') return (
-    <div className="min-h-screen bg-[#E1D9BC] flex items-center justify-center">
-      <div className="text-[#30364F] font-black text-sm uppercase tracking-widest animate-pulse">Loading...</div>
+    <div className="brand-rays min-h-dvh flex items-center justify-center">
+      <div className="brand-seal px-5 py-3 text-sm font-black uppercase tracking-widest text-white animate-pulse">Loading...</div>
     </div>
   )
   if (view === 'no_token') return <NoToken />
   if (view === 'invalid') return <InvalidToken reason="invalid" />
   if (view === 'not_found') return <InvalidToken reason="not_found" />
+  if (view === 'unavailable') return <InvalidToken reason="unavailable" />
   if (view === 'ready' && data) return <RSVPCard data={data} token={token!} />
   return null
 }
@@ -215,8 +434,8 @@ function AttendeeView() {
 export default function Page() {
   return (
     <Suspense fallback={
-      <div className="min-h-screen bg-[#E1D9BC] flex items-center justify-center">
-        <div className="text-[#30364F] font-black text-sm uppercase tracking-widest">Loading...</div>
+      <div className="brand-rays min-h-dvh flex items-center justify-center">
+        <div className="brand-seal px-5 py-3 text-sm font-black uppercase tracking-widest text-white">Loading...</div>
       </div>
     }>
       <AttendeeView />

--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -2,6 +2,25 @@ import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
   output: "standalone",
+  async headers() {
+    return [
+      {
+        source: "/admin/:path*",
+        headers: [
+          { key: "Permissions-Policy", value: "camera=(self), microphone=(), geolocation=()" },
+        ],
+      },
+      {
+        source: "/:path*",
+        headers: [
+          { key: "X-Content-Type-Options", value: "nosniff" },
+          { key: "X-Frame-Options", value: "DENY" },
+          { key: "Referrer-Policy", value: "strict-origin-when-cross-origin" },
+          { key: "Content-Security-Policy", value: "frame-ancestors 'none'; base-uri 'self'; form-action 'self'" },
+        ],
+      },
+    ];
+  },
 };
 
 export default nextConfig;


### PR DESCRIPTION
## Summary

Gives the `frontend/` a distinct **izakaya / 大衆酒場 matsuri brand identity** — so the attendee pass and the door check-in tool feel like a Chiba-chan-style offkai rather than a neutral template — **without changing the data contract or any admin behaviour.**

This is a **pure re-skin of `frontend/`**. Every API route, the multi-event logic, string snowflake `user_id`s, HMAC token verification, QR scan, manual check-in/out, sticky-undo, polling, and group-size counters are kept verbatim.

## Before / After

| | Before (current `frontend/`) | After (this PR) |
|---|---|---|
| **Attendee — mobile** | ![](https://raw.githubusercontent.com/hamzaabamboo/offkai-bot/pr-evidence/before/attendee-mobile.png) | ![](https://raw.githubusercontent.com/hamzaabamboo/offkai-bot/pr-evidence/after/attendee-mobile.png) |
| **Admin door — mobile** | ![](https://raw.githubusercontent.com/hamzaabamboo/offkai-bot/pr-evidence/before/admin-mobile.png) | ![](https://raw.githubusercontent.com/hamzaabamboo/offkai-bot/pr-evidence/after/admin-mobile.png) |
| **Attendee — desktop** | ![](https://raw.githubusercontent.com/hamzaabamboo/offkai-bot/pr-evidence/before/attendee-desktop.png) | ![](https://raw.githubusercontent.com/hamzaabamboo/offkai-bot/pr-evidence/after/attendee-desktop.png) |
| **Admin door — desktop** | ![](https://raw.githubusercontent.com/hamzaabamboo/offkai-bot/pr-evidence/before/admin-desktop.png) | ![](https://raw.githubusercontent.com/hamzaabamboo/offkai-bot/pr-evidence/after/admin-desktop.png) |

## Demo — full flow (mock mode)

Attendee pass → admin login → switch event → manual check-in (count + row update, group-counted) → check-out:

![demo](https://raw.githubusercontent.com/hamzaabamboo/offkai-bot/pr-evidence/after/flow.gif)

High-quality MP4: https://raw.githubusercontent.com/hamzaabamboo/offkai-bot/pr-evidence/after/flow.mp4

Admin after two check-ins (Fadekyun party of 2 + Sakichan = **3 In / 6 People**, group-counted):

![checked in](https://raw.githubusercontent.com/hamzaabamboo/offkai-bot/pr-evidence/after/admin-checkedin.png)

## What the redesign adds

- **Storefront masthead**: rising-sun (旭日) sunburst, brush wordmark + smiley mark, a 大衆酒場 banner, a 提灯 lantern garland (大衆酒場乾杯祭), and a バカ盛り karaage-boat illustration.
- **Brutalist sticker construction**: 2px ink borders + hard offset shadows, hanko stamps, ink title plaques, and a 豆絞り dotted festival ground.
- **Type**: `Dela Gothic One` (display) + `Reggae One` (brush wordmark), self-hosted via `next/font` — no external font requests, no layout shift.

## Behaviour kept identical (verbatim logic)

- Multi-event selector + `getDefaultEvent` / dropdown ordering, scoped per-event API calls
- String snowflake `user_id`s end-to-end; HMAC (legacy + v2) token verification
- QR scan (same-origin guard, pre-loaded `html5-qrcode`), manual check-in **and** check-out (POST `action=checkout`)
- Sticky-undo rows, 10s check-in polling, people (group-size) counters, waitlist section

## UX / accessibility improvements (no contract change)

- Re-enable pinch-zoom (drop `user-scalable=no`); all touch targets ≥44px; on-brand focus rings; `prefers-reduced-motion` disables the lantern sway; QR has an accessible name; status never relies on colour alone.
- Attendee: explicit retry state on 5xx; admin search also matches `#id` / `@handle`.
- `next.config`: scope the camera `Permissions-Policy` to `/admin` (where the scanner runs) and add baseline security headers (`nosniff`, `frame-ancestors 'none'`, `referrer-policy`).

## Testing

- `npm run lint` clean; `npm run build` succeeds (Next 16, TS clean).
- Production build (`next start`, `MOCK_MODE=true ADMIN_KEY=demo`) browser-tested at 390 / 1440:
  - attendee pass (v2 token), admin login, event switch (Bandori/MyGO/Roselia), manual check-in + check-out, search, filters, waitlist.
  - check-in/out API verified end-to-end (record created → listed → removed); `console` / page `errors` empty.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
