### PR TITLE
Implement persistent attendee numbering

### DIFF
--- a/bot/src/offkai_bot/cogs/events.py
+++ b/bot/src/offkai_bot/cogs/events.py
@@ -71,7 +71,9 @@ DISCORD_MESSAGE_SOFT_LIMIT = 1900
 def _format_attendance_output(event_name: str, total_count: int, attendee_list: list[str]) -> str:
     output = f"**Attendance for {event_name}**\n\n"
     output += f"Total Attendees: **{total_count}**\n\n"
-    lines = [f"{getattr(name, 'attendee_number', None) or i + 1}. {name}" for i, name in enumerate(attendee_list)]
+    attendee_numbers = [getattr(name, "attendee_number", None) for name in attendee_list]
+    use_stored_numbers = all(number is not None for number in attendee_numbers)
+    lines = [f"{attendee_numbers[i] if use_stored_numbers else i + 1}. {name}" for i, name in enumerate(attendee_list)]
     output += "\n".join(lines)
     return output
 

--- a/bot/src/offkai_bot/cogs/events.py
+++ b/bot/src/offkai_bot/cogs/events.py
@@ -27,6 +27,7 @@ from offkai_bot.data.response import (
     calculate_attendance,
     calculate_drinks,
     calculate_waitlist,
+    clear_attendee_numbers,
     get_waitlist,
     promote_specific_from_waitlist,
     remove_response,
@@ -70,7 +71,7 @@ DISCORD_MESSAGE_SOFT_LIMIT = 1900
 def _format_attendance_output(event_name: str, total_count: int, attendee_list: list[str]) -> str:
     output = f"**Attendance for {event_name}**\n\n"
     output += f"Total Attendees: **{total_count}**\n\n"
-    lines = [f"{i + 1}. {name}" for i, name in enumerate(attendee_list)]
+    lines = [f"{getattr(name, 'attendee_number', None) or i + 1}. {name}" for i, name in enumerate(attendee_list)]
     output += "\n".join(lines)
     return output
 
@@ -340,6 +341,8 @@ class EventsCog(commands.Cog):
     @log_command_usage
     async def reopen_offkai(self, interaction: discord.Interaction, event_name: str, reopen_msg: str | None = None):
         reopened_event = set_event_open_status(event_name, target_open_status=True)
+        clear_attendee_numbers(event_name)
+        save_responses()
         save_event_data()
         await update_event_message(self.bot, reopened_event)
 
@@ -492,7 +495,7 @@ class EventsCog(commands.Cog):
             extras_names=promoted_entry.extras_names,
             display_name=promoted_entry.display_name,
         )
-        add_response(event_name, promoted_response)
+        add_response(event_name, promoted_response, force_attendee_number=not event.open)
 
         if event.role_id and interaction.guild:
             await assign_event_role(interaction.guild, user_id, event.role_id)

--- a/bot/src/offkai_bot/data/response.py
+++ b/bot/src/offkai_bot/data/response.py
@@ -33,6 +33,8 @@ class Response:
     drinks: list[str] = field(default_factory=list)
     extras_names: list[str] = field(default_factory=list)
     display_name: str | None = None
+    attendee_number: int | None = None
+    extras_attendee_numbers: list[int] = field(default_factory=list)
 
 
 # --- Waitlist Entry Dataclass ---
@@ -56,9 +58,94 @@ class EventData(TypedDict):
     waitlist: list[WaitlistEntry]
 
 
+class NumberedAttendeeName(str):
+    attendee_number: int | None
+
+    def __new__(cls, value: str, attendee_number: int | None = None):
+        obj = str.__new__(cls, value)
+        obj.attendee_number = attendee_number
+        return obj
+
+
 # --- Response Data Handling ---
 
 RESPONSE_DATA_CACHE: dict[str, EventData] | None = None
+
+
+def _parse_optional_int(value: object) -> int | None:
+    if value is None:
+        return None
+    if not isinstance(value, int | str | bytes | bytearray):
+        raise TypeError(f"Expected int-compatible attendee number, got {type(value).__name__}")
+    return int(value)
+
+
+def _parse_int_list(value: object) -> list[int]:
+    if not isinstance(value, list):
+        return []
+    return [int(item) for item in value]
+
+
+def _group_attendee_numbers(response: Response) -> list[int]:
+    numbers = []
+    if response.attendee_number is not None:
+        numbers.append(response.attendee_number)
+    numbers.extend(response.extras_attendee_numbers)
+    return numbers
+
+
+def _event_has_attendee_numbers(event_data: EventData) -> bool:
+    return any(_group_attendee_numbers(response) for response in event_data["attendees"])
+
+
+def _next_attendee_number(event_data: EventData) -> int:
+    assigned_numbers = [
+        number
+        for response in event_data["attendees"]
+        for number in _group_attendee_numbers(response)
+    ]
+    return max(assigned_numbers, default=0) + 1
+
+
+def _assign_group_numbers(response: Response, start_number: int) -> int:
+    response.attendee_number = start_number
+    response.extras_attendee_numbers = list(range(start_number + 1, start_number + 1 + response.extra_people))
+    return start_number + 1 + response.extra_people
+
+
+def _clear_group_numbers(response: Response) -> None:
+    response.attendee_number = None
+    response.extras_attendee_numbers = []
+
+
+def _compact_numbers_after_removal(attendees: list[Response], removed_numbers: list[int]) -> None:
+    if not removed_numbers:
+        return
+
+    sorted_removed = sorted(removed_numbers)
+
+    def compact(number: int | None) -> int | None:
+        if number is None:
+            return None
+        decrement = sum(1 for removed_number in sorted_removed if removed_number < number)
+        return number - decrement
+
+    for response in attendees:
+        response.attendee_number = compact(response.attendee_number)
+        compacted_extras = [compact(number) for number in response.extras_attendee_numbers]
+        response.extras_attendee_numbers = [number for number in compacted_extras if number is not None]
+
+
+def _number_for_extra(response: Response, index: int) -> int | None:
+    if index < len(response.extras_attendee_numbers):
+        return response.extras_attendee_numbers[index]
+    return None
+
+
+def _has_complete_attendee_numbers(responses: list[Response]) -> bool:
+    expected_count = sum(1 + response.extra_people for response in responses)
+    actual_numbers = [number for response in responses for number in _group_attendee_numbers(response)]
+    return sorted(actual_numbers) == list(range(1, expected_count + 1))
 
 
 def _migrate_old_format_to_new(
@@ -115,6 +202,8 @@ def _parse_response_from_dict(resp_dict: dict, event_name: str) -> Response | No
         arrival_confirmed = str(arrival_confirmed_raw).lower() == "yes" or arrival_confirmed_raw is True
         extras_names = resp_dict.get("extras_names", [])
         display_name = resp_dict.get("display_name")
+        attendee_number = _parse_optional_int(resp_dict.get("attendee_number"))
+        extras_attendee_numbers = _parse_int_list(resp_dict.get("extras_attendee_numbers", []))
 
         return Response(
             user_id=int(resp_dict.get("user_id", 0)),
@@ -127,6 +216,8 @@ def _parse_response_from_dict(resp_dict: dict, event_name: str) -> Response | No
             drinks=drinks,
             extras_names=extras_names,
             display_name=display_name,
+            attendee_number=attendee_number,
+            extras_attendee_numbers=extras_attendee_numbers,
         )
     except (TypeError, ValueError) as e:
         _log.error("Error creating Response object for event %s from dict %s: %s", event_name, resp_dict, e)
@@ -386,7 +477,32 @@ def get_waitlist(event_name: str) -> list[WaitlistEntry]:
     return event_data["waitlist"]
 
 
-def add_response(event_name: str, response: Response) -> None:
+def assign_attendee_numbers(event_name: str) -> None:
+    """Assign close-time attendee numbers for confirmed attendees in the response cache."""
+    all_data = load_responses()
+    event_data = all_data.get(event_name, EventData(attendees=[], waitlist=[]))
+
+    next_number = 1
+    for response in sorted(event_data["attendees"], key=lambda r: (r.username.casefold(), r.user_id)):
+        next_number = _assign_group_numbers(response, next_number)
+
+    all_data[event_name] = event_data
+    _log.info("Assigned attendee numbers for event %s.", event_name)
+
+
+def clear_attendee_numbers(event_name: str) -> None:
+    """Clear attendee numbers for an event so the next close can assign them from scratch."""
+    all_data = load_responses()
+    event_data = all_data.get(event_name, EventData(attendees=[], waitlist=[]))
+
+    for response in event_data["attendees"]:
+        _clear_group_numbers(response)
+
+    all_data[event_name] = event_data
+    _log.info("Cleared attendee numbers for event %s.", event_name)
+
+
+def add_response(event_name: str, response: Response, *, force_attendee_number: bool = False) -> None:
     """Adds a response to the specified event's attendees.
 
     Raises:
@@ -406,6 +522,9 @@ def add_response(event_name: str, response: Response) -> None:
         raise DuplicateResponseError(event_name, response.user_id)
 
     # If no duplicate, proceed with adding
+    if force_attendee_number or _event_has_attendee_numbers(event_data):
+        _assign_group_numbers(response, _next_attendee_number(event_data))
+
     event_data["attendees"].append(response)
     all_data[event_name] = event_data
     save_responses()
@@ -421,17 +540,18 @@ def remove_response(event_name: str, user_id: int) -> None:
     all_data = load_responses()
     event_data = all_data.get(event_name, EventData(attendees=[], waitlist=[]))
 
-    initial_count = len(event_data["attendees"])
-    # Filter out the response matching the user_id
-    event_data["attendees"] = [r for r in event_data["attendees"] if r.user_id != user_id]
+    removed_response = next((r for r in event_data["attendees"] if r.user_id == user_id), None)
 
     # Check if any response was actually removed
-    if len(event_data["attendees"]) == initial_count:
+    if removed_response is None:
         # No response found for the user, raise error
         _log.warning("No response found for user %s in event %s to remove. Raising error.", user_id, event_name)
         raise ResponseNotFoundError(event_name, user_id)
     else:
         # Response found and removed, update the cache and save
+        removed_numbers = _group_attendee_numbers(removed_response)
+        event_data["attendees"] = [r for r in event_data["attendees"] if r.user_id != user_id]
+        _compact_numbers_after_removal(event_data["attendees"], removed_numbers)
         all_data[event_name] = event_data
         save_responses()
         _log.info("Removed response from user %s for event %s.", user_id, event_name)
@@ -550,10 +670,11 @@ def calculate_attendance(
     if not responses:
         raise NoResponsesFoundError(event_name)
 
-    if sort:
+    has_complete_attendee_numbers = _has_complete_attendee_numbers(responses)
+    if sort and not has_complete_attendee_numbers:
         responses = sorted(responses, key=lambda r: r.username.lower())
 
-    attendee_names = []
+    attendee_names: list[str] = []
     total_count = 0
     for response in responses:
         # Add the main person
@@ -563,7 +684,7 @@ def calculate_attendance(
         if drinks:
             drink = response.drinks[0] if response.drinks else "N/A"
             name = f"{name} - {drink}"
-        attendee_names.append(name)
+        attendee_names.append(NumberedAttendeeName(name, response.attendee_number))
         total_count += 1
 
         # Add extra people
@@ -576,8 +697,11 @@ def calculate_attendance(
                 drink_index = i + 1
                 drink = response.drinks[drink_index] if drink_index < len(response.drinks) else "N/A"
                 name = f"{name} - {drink}"
-            attendee_names.append(name)
+            attendee_names.append(NumberedAttendeeName(name, _number_for_extra(response, i)))
             total_count += 1
+
+    if has_complete_attendee_numbers:
+        attendee_names = sorted(attendee_names, key=lambda name: getattr(name, "attendee_number"))
 
     _log.info("Calculated attendance for '%s': %s attendees.", event_name, total_count)
     return total_count, attendee_names

--- a/bot/src/offkai_bot/data/response.py
+++ b/bot/src/offkai_bot/data/response.py
@@ -83,7 +83,13 @@ def _parse_optional_int(value: object) -> int | None:
 def _parse_int_list(value: object) -> list[int]:
     if not isinstance(value, list):
         return []
-    return [int(item) for item in value]
+    return [_parse_required_int(item) for item in value]
+
+
+def _parse_required_int(value: object) -> int:
+    if not isinstance(value, int | str | bytes | bytearray):
+        raise TypeError(f"Expected int-compatible attendee number, got {type(value).__name__}")
+    return int(value)
 
 
 def _group_attendee_numbers(response: Response) -> list[int]:

--- a/bot/src/offkai_bot/data/response.py
+++ b/bot/src/offkai_bot/data/response.py
@@ -75,9 +75,7 @@ RESPONSE_DATA_CACHE: dict[str, EventData] | None = None
 def _parse_optional_int(value: object) -> int | None:
     if value is None:
         return None
-    if not isinstance(value, int | str | bytes | bytearray):
-        raise TypeError(f"Expected int-compatible attendee number, got {type(value).__name__}")
-    return int(value)
+    return _parse_required_int(value)
 
 
 def _parse_int_list(value: object) -> list[int]:
@@ -87,7 +85,7 @@ def _parse_int_list(value: object) -> list[int]:
 
 
 def _parse_required_int(value: object) -> int:
-    if not isinstance(value, int | str | bytes | bytearray):
+    if not isinstance(value, int | str):
         raise TypeError(f"Expected int-compatible attendee number, got {type(value).__name__}")
     return int(value)
 
@@ -105,11 +103,7 @@ def _event_has_attendee_numbers(event_data: EventData) -> bool:
 
 
 def _next_attendee_number(event_data: EventData) -> int:
-    assigned_numbers = [
-        number
-        for response in event_data["attendees"]
-        for number in _group_attendee_numbers(response)
-    ]
+    assigned_numbers = [number for response in event_data["attendees"] for number in _group_attendee_numbers(response)]
     return max(assigned_numbers, default=0) + 1
 
 
@@ -663,6 +657,7 @@ def calculate_attendance(
         nicknames: If True, show display names alongside usernames when they differ.
         drinks: If True, append each attendee's drink choice.
         sort: If True, sort based on the main user and bundle extras after them.
+            Ignored for completely numbered events so stored numbers display in sequence.
 
     Returns:
         A tuple containing:

--- a/bot/src/offkai_bot/event_actions.py
+++ b/bot/src/offkai_bot/event_actions.py
@@ -8,6 +8,7 @@ from offkai_bot.data.event import (
     save_event_data,
     set_event_open_status,
 )
+from offkai_bot.data.response import assign_attendee_numbers, save_responses
 from offkai_bot.errors import (
     BotCommandError,
     MissingChannelIDError,
@@ -50,8 +51,10 @@ async def perform_close_event(client: discord.Client, event_name: str, close_msg
 
     # 1. Update status in data store (raises EventNotFoundError if not found)
     closed_event = set_event_open_status(event_name, target_open_status=False)
+    assign_attendee_numbers(event_name)
 
     # 2. Save the change
+    save_responses()
     save_event_data()
     _log.info("Event '%s' status set to closed and data saved.", event_name)
 

--- a/bot/src/offkai_bot/interactions.py
+++ b/bot/src/offkai_bot/interactions.py
@@ -168,7 +168,7 @@ async def promote_waitlist_batch(event: Event, client: discord.Client) -> list[i
             extras_names=promoted_entry.extras_names,
             display_name=promoted_entry.display_name,
         )
-        add_response(event.event_name, promoted_response)
+        add_response(event.event_name, promoted_response, force_attendee_number=not event.open)
         promoted_count += 1
         promoted_user_ids.append(promoted_entry.user_id)
 

--- a/bot/tests/alerts/test_checkin_reminder.py
+++ b/bot/tests/alerts/test_checkin_reminder.py
@@ -5,7 +5,6 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import discord
 import pytest
-from offkai_bot.alerts import alerts
 from offkai_bot.alerts.reminders import (
     CHECKIN_REMINDER_LEAD,
     SendCheckinReminderTask,
@@ -15,6 +14,8 @@ from offkai_bot.alerts.reminders import (
 )
 from offkai_bot.data.event import Event
 from offkai_bot.data.response import Response
+
+from offkai_bot.alerts import alerts
 
 # --- Fixtures ---
 

--- a/bot/tests/alerts/test_fire_alerts.py
+++ b/bot/tests/alerts/test_fire_alerts.py
@@ -5,11 +5,11 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import discord
 import pytest
+from offkai_bot.alerts.task import Task  # Import base Task for type hinting
+from offkai_bot.util import JST  # Import the JST timezone object
 
 # Import the module and functions to test
 from offkai_bot.alerts import alerts
-from offkai_bot.alerts.task import Task  # Import base Task for type hinting
-from offkai_bot.util import JST  # Import the JST timezone object
 
 # pytest marker for async tests
 pytestmark = pytest.mark.asyncio

--- a/bot/tests/alerts/test_register_alerts.py
+++ b/bot/tests/alerts/test_register_alerts.py
@@ -5,9 +5,6 @@ from unittest.mock import ANY, AsyncMock, MagicMock, patch
 
 import discord
 import pytest
-
-# Import the module and functions to test
-from offkai_bot.alerts import alerts
 from offkai_bot.alerts.reminders import register_deadline_reminders
 from offkai_bot.alerts.task import (  # Import base Task for type hinting
     CloseOffkaiTask,
@@ -18,6 +15,9 @@ from offkai_bot.alerts.task import (  # Import base Task for type hinting
 from offkai_bot.data.event import Event
 from offkai_bot.errors import AlertTimeInPastError
 from offkai_bot.util import JST  # Import the JST timezone object
+
+# Import the module and functions to test
+from offkai_bot.alerts import alerts
 
 # --- Fixtures ---
 

--- a/bot/tests/commands/test_attendance.py
+++ b/bot/tests/commands/test_attendance.py
@@ -8,7 +8,8 @@ from discord import app_commands
 from discord.ext import commands
 
 # Import the function to test and relevant errors/classes
-from offkai_bot.cogs.events import EventsCog
+from offkai_bot.cogs.events import EventsCog, _format_attendance_output
+from offkai_bot.data.response import NumberedAttendeeName
 from offkai_bot.errors import (
     EventNotFoundError,
     NoResponsesFoundError,
@@ -61,6 +62,17 @@ def mock_event_obj(sample_event_list):
 
 
 # --- Test Cases ---
+
+
+async def test_format_attendance_output_uses_persisted_attendee_numbers():
+    attendee_list = [
+        NumberedAttendeeName("Alice", 4),
+        NumberedAttendeeName("Bob", 5),
+    ]
+
+    output = _format_attendance_output("Summer Bash", 2, attendee_list)
+
+    assert output == "**Attendance for Summer Bash**\n\nTotal Attendees: **2**\n\n4. Alice\n5. Bob"
 
 
 @patch("offkai_bot.cogs.events.calculate_attendance")

--- a/bot/tests/commands/test_attendance.py
+++ b/bot/tests/commands/test_attendance.py
@@ -75,6 +75,17 @@ async def test_format_attendance_output_uses_persisted_attendee_numbers():
     assert output == "**Attendance for Summer Bash**\n\nTotal Attendees: **2**\n\n4. Alice\n5. Bob"
 
 
+async def test_format_attendance_output_uses_dynamic_numbers_for_partial_numbering():
+    attendee_list = [
+        NumberedAttendeeName("Alice", 4),
+        "Bob",
+    ]
+
+    output = _format_attendance_output("Summer Bash", 2, attendee_list)
+
+    assert output == "**Attendance for Summer Bash**\n\nTotal Attendees: **2**\n\n1. Alice\n2. Bob"
+
+
 @patch("offkai_bot.cogs.events.calculate_attendance")
 @patch("offkai_bot.cogs.events.get_event")
 @patch("offkai_bot.cogs.events._log")

--- a/bot/tests/commands/test_capacity_waitlist.py
+++ b/bot/tests/commands/test_capacity_waitlist.py
@@ -7,7 +7,6 @@ import discord
 import pytest
 from discord.ext import commands
 from offkai_bot.cogs.events import EventsCog
-from offkai_bot.data import response as response_data
 from offkai_bot.data.event import Event
 from offkai_bot.data.response import Response, WaitlistEntry, add_response, add_to_waitlist, get_responses, get_waitlist
 from offkai_bot.interactions import (
@@ -17,6 +16,8 @@ from offkai_bot.interactions import (
     is_event_at_capacity,
     would_exceed_capacity,
 )
+
+from offkai_bot.data import response as response_data
 
 # --- Fixtures ---
 

--- a/bot/tests/commands/test_closed_attendance_count.py
+++ b/bot/tests/commands/test_closed_attendance_count.py
@@ -6,11 +6,12 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 from discord.ext import commands
 from offkai_bot.cogs.events import EventsCog
-from offkai_bot.data import event as event_data
-from offkai_bot.data import response as response_data
 from offkai_bot.data.event import Event, set_event_open_status
 from offkai_bot.data.response import Response, WaitlistEntry, add_response, add_to_waitlist, get_responses, get_waitlist
 from offkai_bot.interactions import ClosedEvent, get_current_attendance_count
+
+from offkai_bot.data import event as event_data
+from offkai_bot.data import response as response_data
 
 
 @pytest.fixture

--- a/bot/tests/conftest.py
+++ b/bot/tests/conftest.py
@@ -4,10 +4,11 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import discord
 import pytest
+from offkai_bot.data.event import Event
+
 from offkai_bot.data import event as event_data
 from offkai_bot.data import ranking as ranking_data
 from offkai_bot.data import response as response_data
-from offkai_bot.data.event import Event
 
 
 @pytest.fixture(scope="module")  # Change scope to "module"

--- a/bot/tests/data/test_event.py
+++ b/bot/tests/data/test_event.py
@@ -5,9 +5,6 @@ from datetime import UTC, datetime, timedelta
 from unittest.mock import mock_open, patch
 
 import pytest
-
-# Import the module we are testing
-from offkai_bot.data import event as event_data
 from offkai_bot.data.encoders import DataclassJSONEncoder  # Needed for save verification
 from offkai_bot.data.event import JST, OFFKAI_MESSAGE, Event, create_event_message
 from offkai_bot.errors import (
@@ -22,6 +19,9 @@ from offkai_bot.errors import (
     InvalidDateTimeFormatError,
     NoChangesProvidedError,
 )  # Import the dataclass too
+
+# Import the module we are testing
+from offkai_bot.data import event as event_data
 
 # --- Test Data ---
 # Use explicit future dates for reliability

--- a/bot/tests/data/test_ranking.py
+++ b/bot/tests/data/test_ranking.py
@@ -2,9 +2,10 @@
 import json
 from unittest.mock import mock_open, patch
 
-from offkai_bot.data import ranking as ranking_data
 from offkai_bot.data.encoders import DataclassJSONEncoder
 from offkai_bot.data.ranking import UserRank
+
+from offkai_bot.data import ranking as ranking_data
 
 # --- Test Data ---
 RANK_1_DICT = {

--- a/bot/tests/data/test_response.py
+++ b/bot/tests/data/test_response.py
@@ -4,12 +4,12 @@ from datetime import UTC, datetime
 from unittest.mock import mock_open, patch
 
 import pytest
-
-# Import the module we are testing
-from offkai_bot.data import response as response_data
 from offkai_bot.data.encoders import DataclassJSONEncoder  # Needed for save verification
 from offkai_bot.data.response import EventData, Response, WaitlistEntry
 from offkai_bot.errors import DuplicateResponseError, NoWaitlistEntriesFoundError, ResponseNotFoundError
+
+# Import the module we are testing
+from offkai_bot.data import response as response_data
 
 # --- Test Data ---
 NOW = datetime.now(UTC)
@@ -453,6 +453,33 @@ def test_save_responses_os_error(mock_paths):
         mock_log.error.assert_called_once()
         assert "Error writing response data" in mock_log.error.call_args[0][0]
         assert "Permission denied" in str(mock_log.error.call_args)
+
+
+def test_save_responses_includes_attendee_numbers(mock_paths):
+    """Test saving numbered response fields."""
+    numbered_response = Response(
+        user_id=111,
+        username="NumberedUser",
+        extra_people=2,
+        behavior_confirmed=True,
+        arrival_confirmed=True,
+        event_name="Event A",
+        timestamp=NOW,
+        drinks=[],
+        extras_names=["Guest A", "Guest B"],
+        attendee_number=4,
+        extras_attendee_numbers=[5, 6],
+    )
+    response_data.RESPONSE_DATA_CACHE = {"Event A": make_event_data([numbered_response])}
+
+    response_data.save_responses()
+
+    with open(mock_paths["responses"], encoding="utf-8") as file:
+        saved_data = json.load(file)
+
+    saved_response = saved_data["Event A"]["attendees"][0]
+    assert saved_response["attendee_number"] == 4
+    assert saved_response["extras_attendee_numbers"] == [5, 6]
 
 
 # == get_responses Tests ==
@@ -1223,6 +1250,37 @@ def test_parse_response_without_display_name_field(mock_paths):
         assert loaded_resp.display_name is None
 
 
+def test_parse_response_without_attendee_number_fields(mock_paths):
+    """Test parsing Response from old JSON without attendee number fields."""
+    with (
+        patch("os.path.exists", return_value=True),
+        patch("os.path.getsize", return_value=100),
+        patch("builtins.open", mock_open(read_data=json.dumps({"Event A": [RESP_1_DICT]}))),
+        patch("offkai_bot.data.response.save_responses"),
+    ):
+        responses = response_data._load_responses()
+
+        loaded_resp = responses["Event A"]["attendees"][0]
+        assert loaded_resp.attendee_number is None
+        assert loaded_resp.extras_attendee_numbers == []
+
+
+def test_parse_response_with_attendee_number_fields(mock_paths):
+    """Test parsing Response with persisted attendee number fields."""
+    numbered_dict = RESP_4_DICT | {"attendee_number": 7, "extras_attendee_numbers": [8, 9]}
+    with (
+        patch("os.path.exists", return_value=True),
+        patch("os.path.getsize", return_value=100),
+        patch("builtins.open", mock_open(read_data=json.dumps({"Event A": [numbered_dict]}))),
+        patch("offkai_bot.data.response.save_responses"),
+    ):
+        responses = response_data._load_responses()
+
+        loaded_resp = responses["Event A"]["attendees"][0]
+        assert loaded_resp.attendee_number == 7
+        assert loaded_resp.extras_attendee_numbers == [8, 9]
+
+
 # --- Tests for calculate_attendance with nicknames ---
 
 
@@ -1543,3 +1601,193 @@ def test_calculate_waitlist_sorting_bundles_extras_after_main_user(mock_paths):
         "AB (B +2)",
         "C",
     ]
+
+
+# --- Tests for persistent attendee numbering ---
+
+
+def test_assign_attendee_numbers_sorts_by_username_and_user_id_with_extras(mock_paths):
+    """Test close-time numbering sorts primaries and keeps extras after inviter."""
+    bob = Response(
+        user_id=2,
+        username="bob",
+        extra_people=0,
+        behavior_confirmed=True,
+        arrival_confirmed=True,
+        event_name="Event N",
+        timestamp=NOW,
+    )
+    alice_with_guests = Response(
+        user_id=3,
+        username="Alice",
+        extra_people=2,
+        behavior_confirmed=True,
+        arrival_confirmed=True,
+        event_name="Event N",
+        timestamp=NOW,
+        extras_names=["Guest 1", "Guest 2"],
+    )
+    alice_tie = Response(
+        user_id=1,
+        username="alice",
+        extra_people=0,
+        behavior_confirmed=True,
+        arrival_confirmed=True,
+        event_name="Event N",
+        timestamp=NOW,
+    )
+    response_data.RESPONSE_DATA_CACHE = {"Event N": make_event_data([bob, alice_with_guests, alice_tie])}
+
+    response_data.assign_attendee_numbers("Event N")
+
+    assert alice_tie.attendee_number == 1
+    assert alice_with_guests.attendee_number == 2
+    assert alice_with_guests.extras_attendee_numbers == [3, 4]
+    assert bob.attendee_number == 5
+
+
+def test_add_response_appends_attendee_numbers_for_numbered_event(mock_paths):
+    """Test adding after close appends numbers after the current max."""
+    existing = Response(
+        user_id=1,
+        username="Existing",
+        extra_people=1,
+        behavior_confirmed=True,
+        arrival_confirmed=True,
+        event_name="Event N",
+        timestamp=NOW,
+        attendee_number=1,
+        extras_attendee_numbers=[2],
+    )
+    response_data.RESPONSE_DATA_CACHE = {"Event N": make_event_data([existing])}
+    added = Response(
+        user_id=2,
+        username="Added",
+        extra_people=2,
+        behavior_confirmed=True,
+        arrival_confirmed=True,
+        event_name="Event N",
+        timestamp=NOW,
+    )
+
+    response_data.add_response("Event N", added)
+
+    assert added.attendee_number == 3
+    assert added.extras_attendee_numbers == [4, 5]
+
+
+def test_add_response_can_force_attendee_numbers_for_empty_closed_event(mock_paths):
+    """Test promoting into a closed event with no existing numbers starts at one."""
+    response_data.RESPONSE_DATA_CACHE = {"Event N": make_event_data([])}
+    added = Response(
+        user_id=2,
+        username="Added",
+        extra_people=1,
+        behavior_confirmed=True,
+        arrival_confirmed=True,
+        event_name="Event N",
+        timestamp=NOW,
+    )
+
+    response_data.add_response("Event N", added, force_attendee_number=True)
+
+    assert added.attendee_number == 1
+    assert added.extras_attendee_numbers == [2]
+
+
+def test_remove_response_compacts_later_attendee_numbers_by_group_size(mock_paths):
+    """Test removing a numbered response with guests compacts later numbers."""
+    first = Response(
+        user_id=1,
+        username="First",
+        extra_people=0,
+        behavior_confirmed=True,
+        arrival_confirmed=True,
+        event_name="Event N",
+        timestamp=NOW,
+        attendee_number=1,
+    )
+    removed = Response(
+        user_id=2,
+        username="Removed",
+        extra_people=2,
+        behavior_confirmed=True,
+        arrival_confirmed=True,
+        event_name="Event N",
+        timestamp=NOW,
+        attendee_number=2,
+        extras_attendee_numbers=[3, 4],
+    )
+    later = Response(
+        user_id=3,
+        username="Later",
+        extra_people=1,
+        behavior_confirmed=True,
+        arrival_confirmed=True,
+        event_name="Event N",
+        timestamp=NOW,
+        attendee_number=5,
+        extras_attendee_numbers=[6],
+    )
+    response_data.RESPONSE_DATA_CACHE = {"Event N": make_event_data([first, removed, later])}
+
+    response_data.remove_response("Event N", removed.user_id)
+
+    assert response_data.get_responses("Event N") == [first, later]
+    assert first.attendee_number == 1
+    assert later.attendee_number == 2
+    assert later.extras_attendee_numbers == [3]
+
+
+def test_clear_attendee_numbers_removes_all_numbers(mock_paths):
+    """Test reopen clearing removes all attendee numbers for an event."""
+    response = Response(
+        user_id=1,
+        username="User",
+        extra_people=1,
+        behavior_confirmed=True,
+        arrival_confirmed=True,
+        event_name="Event N",
+        timestamp=NOW,
+        attendee_number=1,
+        extras_attendee_numbers=[2],
+    )
+    response_data.RESPONSE_DATA_CACHE = {"Event N": make_event_data([response])}
+
+    response_data.clear_attendee_numbers("Event N")
+
+    assert response.attendee_number is None
+    assert response.extras_attendee_numbers == []
+
+
+def test_calculate_attendance_uses_stored_number_order(mock_paths):
+    """Test numbered closed events are listed by persisted attendee number."""
+    later = Response(
+        user_id=2,
+        username="Later",
+        extra_people=0,
+        behavior_confirmed=True,
+        arrival_confirmed=True,
+        event_name="Event N",
+        timestamp=NOW,
+        attendee_number=2,
+    )
+    first = Response(
+        user_id=1,
+        username="First",
+        extra_people=1,
+        behavior_confirmed=True,
+        arrival_confirmed=True,
+        event_name="Event N",
+        timestamp=NOW,
+        extras_names=["Guest"],
+        attendee_number=1,
+        extras_attendee_numbers=[3],
+    )
+    response_data.RESPONSE_DATA_CACHE = {"Event N": make_event_data([later, first])}
+
+    total_count, attendee_names = response_data.calculate_attendance("Event N")
+
+    assert total_count == 3
+    assert attendee_names == ["First", "Later", "Guest (First +1)"]
+    assert [getattr(name, "attendee_number") for name in attendee_names] == [1, 2, 3]

--- a/bot/tests/test_event_message_handling.py
+++ b/bot/tests/test_event_message_handling.py
@@ -3,9 +3,6 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import discord
 import pytest
-
-# Import module and functions under test
-from offkai_bot import event_actions, interactions
 from offkai_bot.data.event import Event
 from offkai_bot.errors import (
     MissingChannelIDError,
@@ -13,6 +10,9 @@ from offkai_bot.errors import (
     ThreadNotFoundError,
 )
 from offkai_bot.main import load_and_update_events
+
+# Import module and functions under test
+from offkai_bot import event_actions, interactions
 
 # pytest marker for async tests
 pytestmark = pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- Persist attendee numbers on confirmed responses, including guest numbers
- Assign numbers on close by username/user ID with guests immediately after their inviter
- Append numbers for closed-event promotions/additions and compact later numbers on removal
- Clear numbers on reopen and use stored numbers in attendance output

## Validation
- `uv run ruff check . --fix`
- `uv run ruff check .`
- `uv run mypy bot\src`
- `uv run pytest`