### PR TITLE
Send long attendance output by DM file

### DIFF
--- a/bot/src/offkai_bot/cogs/events.py
+++ b/bot/src/offkai_bot/cogs/events.py
@@ -547,7 +547,7 @@ class EventsCog(commands.Cog):
 
         output = _format_attendance_output(event_name, total_count, attendee_list)
 
-        if total_count > ATTENDANCE_FILE_THRESHOLD:
+        if total_count > ATTENDANCE_FILE_THRESHOLD or len(output) > DISCORD_MESSAGE_SOFT_LIMIT:
             try:
                 await interaction.user.send(
                     f"Attendance for **{event_name}** is attached as a text file.",
@@ -570,9 +570,6 @@ class EventsCog(commands.Cog):
                     ephemeral=True,
                 )
             return
-
-        if len(output) > DISCORD_MESSAGE_SOFT_LIMIT:
-            output = output[:DISCORD_MESSAGE_SOFT_LIMIT] + "\n... (list truncated)"
 
         await interaction.response.send_message(output, ephemeral=True)
 

--- a/bot/tests/alerts/test_checkin_reminder.py
+++ b/bot/tests/alerts/test_checkin_reminder.py
@@ -5,7 +5,6 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import discord
 import pytest
-from offkai_bot.alerts import alerts
 from offkai_bot.alerts.reminders import (
     CHECKIN_REMINDER_LEAD,
     SendCheckinReminderTask,
@@ -15,6 +14,8 @@ from offkai_bot.alerts.reminders import (
 )
 from offkai_bot.data.event import Event
 from offkai_bot.data.response import Response
+
+from offkai_bot.alerts import alerts
 
 # --- Fixtures ---
 

--- a/bot/tests/alerts/test_fire_alerts.py
+++ b/bot/tests/alerts/test_fire_alerts.py
@@ -5,11 +5,11 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import discord
 import pytest
+from offkai_bot.alerts.task import Task  # Import base Task for type hinting
+from offkai_bot.util import JST  # Import the JST timezone object
 
 # Import the module and functions to test
 from offkai_bot.alerts import alerts
-from offkai_bot.alerts.task import Task  # Import base Task for type hinting
-from offkai_bot.util import JST  # Import the JST timezone object
 
 # pytest marker for async tests
 pytestmark = pytest.mark.asyncio

--- a/bot/tests/alerts/test_register_alerts.py
+++ b/bot/tests/alerts/test_register_alerts.py
@@ -5,9 +5,6 @@ from unittest.mock import ANY, AsyncMock, MagicMock, patch
 
 import discord
 import pytest
-
-# Import the module and functions to test
-from offkai_bot.alerts import alerts
 from offkai_bot.alerts.reminders import register_deadline_reminders
 from offkai_bot.alerts.task import (  # Import base Task for type hinting
     CloseOffkaiTask,
@@ -18,6 +15,9 @@ from offkai_bot.alerts.task import (  # Import base Task for type hinting
 from offkai_bot.data.event import Event
 from offkai_bot.errors import AlertTimeInPastError
 from offkai_bot.util import JST  # Import the JST timezone object
+
+# Import the module and functions to test
+from offkai_bot.alerts import alerts
 
 # --- Fixtures ---
 

--- a/bot/tests/commands/test_attendance.py
+++ b/bot/tests/commands/test_attendance.py
@@ -205,37 +205,37 @@ async def test_attendance_sort_success(
     mock_log.warning.assert_not_called()
 
 
+@patch("offkai_bot.cogs.events.discord.File")
 @patch("offkai_bot.cogs.events.calculate_attendance")
 @patch("offkai_bot.cogs.events.get_event")
 @patch("offkai_bot.cogs.events._log")
-async def test_attendance_success_truncation(
+async def test_attendance_long_output_under_100_sends_file_by_dm(
     mock_log,
     mock_get_event,
     mock_calculate_attendance,
+    mock_discord_file,
     mock_interaction,
     mock_event_obj,
     prepopulated_event_cache,
     mock_cog,
 ):
-    """Test attendance output truncation when the list is very long."""
+    """Test attendance sends a full DM text file when output is too long."""
     # Arrange
     event_name_target = "Summer Bash"
     mock_get_event.return_value = mock_event_obj
+    mock_interaction.user.send = AsyncMock()
+    mock_file = MagicMock()
+    mock_discord_file.return_value = mock_file
 
-    # Create a very long list of attendees
     long_attendee_list = [f"User{i:03d}" for i in range(1000)]
     mock_total_count = 100
     mock_calculate_attendance.return_value = (mock_total_count, long_attendee_list)
 
-    # Construct the expected *full* output first to check length
     full_output_list = "\n".join(f"{i + 1}. {name}" for i, name in enumerate(long_attendee_list))
     full_output = (
         f"**Attendance for {event_name_target}**\n\nTotal Attendees: **{mock_total_count}**\n\n{full_output_list}"
     )
     assert len(full_output) > 1900  # Verify our test data causes truncation
-
-    # Construct the expected truncated output
-    expected_truncated_output = full_output[:1900] + "\n... (list truncated)"
 
     # Act
     await EventsCog.attendance.callback(
@@ -247,7 +247,18 @@ async def test_attendance_success_truncation(
     # Assert
     mock_get_event.assert_called_once_with(event_name_target)
     mock_calculate_attendance.assert_called_once_with(event_name_target, nicknames=False, drinks=False, sort=False)
-    mock_interaction.response.send_message.assert_awaited_once_with(expected_truncated_output, ephemeral=True)
+    mock_discord_file.assert_called_once()
+    assert mock_discord_file.call_args.kwargs["filename"] == "attendance_Summer_Bash.txt"
+    assert mock_discord_file.call_args.kwargs["fp"].getvalue() == full_output.encode("utf-8")
+    mock_interaction.user.send.assert_awaited_once_with(
+        f"Attendance for **{event_name_target}** is attached as a text file.",
+        file=mock_file,
+    )
+    mock_interaction.response.send_message.assert_awaited_once_with(
+        f"Attendance list for '{event_name_target}' has been sent to you by DM.",
+        ephemeral=True,
+    )
+    mock_log.warning.assert_not_called()
 
 
 @patch("offkai_bot.cogs.events.discord.File")

--- a/bot/tests/commands/test_capacity_waitlist.py
+++ b/bot/tests/commands/test_capacity_waitlist.py
@@ -7,7 +7,6 @@ import discord
 import pytest
 from discord.ext import commands
 from offkai_bot.cogs.events import EventsCog
-from offkai_bot.data import response as response_data
 from offkai_bot.data.event import Event
 from offkai_bot.data.response import Response, WaitlistEntry, add_response, add_to_waitlist, get_responses, get_waitlist
 from offkai_bot.interactions import (
@@ -17,6 +16,8 @@ from offkai_bot.interactions import (
     is_event_at_capacity,
     would_exceed_capacity,
 )
+
+from offkai_bot.data import response as response_data
 
 # --- Fixtures ---
 

--- a/bot/tests/commands/test_closed_attendance_count.py
+++ b/bot/tests/commands/test_closed_attendance_count.py
@@ -6,11 +6,12 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 from discord.ext import commands
 from offkai_bot.cogs.events import EventsCog
-from offkai_bot.data import event as event_data
-from offkai_bot.data import response as response_data
 from offkai_bot.data.event import Event, set_event_open_status
 from offkai_bot.data.response import Response, WaitlistEntry, add_response, add_to_waitlist, get_responses, get_waitlist
 from offkai_bot.interactions import ClosedEvent, get_current_attendance_count
+
+from offkai_bot.data import event as event_data
+from offkai_bot.data import response as response_data
 
 
 @pytest.fixture

--- a/bot/tests/conftest.py
+++ b/bot/tests/conftest.py
@@ -4,10 +4,11 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import discord
 import pytest
+from offkai_bot.data.event import Event
+
 from offkai_bot.data import event as event_data
 from offkai_bot.data import ranking as ranking_data
 from offkai_bot.data import response as response_data
-from offkai_bot.data.event import Event
 
 
 @pytest.fixture(scope="module")  # Change scope to "module"

--- a/bot/tests/data/test_event.py
+++ b/bot/tests/data/test_event.py
@@ -5,9 +5,6 @@ from datetime import UTC, datetime, timedelta
 from unittest.mock import mock_open, patch
 
 import pytest
-
-# Import the module we are testing
-from offkai_bot.data import event as event_data
 from offkai_bot.data.encoders import DataclassJSONEncoder  # Needed for save verification
 from offkai_bot.data.event import JST, OFFKAI_MESSAGE, Event, create_event_message
 from offkai_bot.errors import (
@@ -22,6 +19,9 @@ from offkai_bot.errors import (
     InvalidDateTimeFormatError,
     NoChangesProvidedError,
 )  # Import the dataclass too
+
+# Import the module we are testing
+from offkai_bot.data import event as event_data
 
 # --- Test Data ---
 # Use explicit future dates for reliability

--- a/bot/tests/data/test_ranking.py
+++ b/bot/tests/data/test_ranking.py
@@ -2,9 +2,10 @@
 import json
 from unittest.mock import mock_open, patch
 
-from offkai_bot.data import ranking as ranking_data
 from offkai_bot.data.encoders import DataclassJSONEncoder
 from offkai_bot.data.ranking import UserRank
+
+from offkai_bot.data import ranking as ranking_data
 
 # --- Test Data ---
 RANK_1_DICT = {

--- a/bot/tests/data/test_response.py
+++ b/bot/tests/data/test_response.py
@@ -4,12 +4,12 @@ from datetime import UTC, datetime
 from unittest.mock import mock_open, patch
 
 import pytest
-
-# Import the module we are testing
-from offkai_bot.data import response as response_data
 from offkai_bot.data.encoders import DataclassJSONEncoder  # Needed for save verification
 from offkai_bot.data.response import EventData, Response, WaitlistEntry
 from offkai_bot.errors import DuplicateResponseError, NoWaitlistEntriesFoundError, ResponseNotFoundError
+
+# Import the module we are testing
+from offkai_bot.data import response as response_data
 
 # --- Test Data ---
 NOW = datetime.now(UTC)

--- a/bot/tests/test_event_message_handling.py
+++ b/bot/tests/test_event_message_handling.py
@@ -3,9 +3,6 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import discord
 import pytest
-
-# Import module and functions under test
-from offkai_bot import event_actions, interactions
 from offkai_bot.data.event import Event
 from offkai_bot.errors import (
     MissingChannelIDError,
@@ -13,6 +10,9 @@ from offkai_bot.errors import (
     ThreadNotFoundError,
 )
 from offkai_bot.main import load_and_update_events
+
+# Import module and functions under test
+from offkai_bot import event_actions, interactions
 
 # pytest marker for async tests
 pytestmark = pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- Send `/attendance` output as a DM text file when the formatted message exceeds the Discord soft limit, even if attendee count is 100 or lower
- Keep the existing >100 attendee file behavior and fallback ephemeral attachment when DMs fail
- Update attendance coverage for long output below the old attendee-count threshold
- Apply Ruff import-order fixes in tests

## Tests
- `uv run ruff check . --fix`
- `uv run mypy src/`
- `uv run pytest`