### PR TITLE
Add attendee numbers to reminder DMs

### DIFF
--- a/bot/src/offkai_bot/alerts/reminders.py
+++ b/bot/src/offkai_bot/alerts/reminders.py
@@ -22,6 +22,31 @@ _DM_THROTTLE_SECONDS = 0.5
 _log = logging.getLogger(__name__)
 
 
+def _format_attendee_numbers_en(response: Response) -> str | None:
+    if response.attendee_number is None:
+        return None
+
+    parts = [f"{response.attendee_number} (you)"]
+    for index, number in enumerate(response.extras_attendee_numbers):
+        guest_name = response.extras_names[index] if index < len(response.extras_names) else f"guest {index + 1}"
+        parts.append(f"{number} ({guest_name})")
+
+    label = "Attendee Number" if len(parts) == 1 else "Attendee Numbers"
+    return f"🔢 **{label}:** {', '.join(parts)}"
+
+
+def _format_attendee_numbers_jp(response: Response) -> str | None:
+    if response.attendee_number is None:
+        return None
+
+    parts = [f"{response.attendee_number}（本人）"]
+    for index, number in enumerate(response.extras_attendee_numbers):
+        guest_name = response.extras_names[index] if index < len(response.extras_names) else f"同伴者{index + 1}"
+        parts.append(f"{number}（{guest_name}）")
+
+    return f"🔢 **受付番号:** {', '.join(parts)}"
+
+
 def register_deadline_reminders(client: discord.Client, event: Event, thread: discord.Thread):
     _log.info("Registering deadline reminders for event '%s'.", event.event_name)
 
@@ -98,6 +123,8 @@ def build_checkin_reminder_message(event: Event, response: Response, rsvp_url: s
     extra_people = response.extra_people or 0
     extras_names = response.extras_names or []
     drinks = response.drinks or []
+    attendee_numbers_en = _format_attendee_numbers_en(response)
+    attendee_numbers_jp = _format_attendee_numbers_jp(response)
 
     # --- English ---
     en = [
@@ -108,6 +135,8 @@ def build_checkin_reminder_message(event: Event, response: Response, rsvp_url: s
         f"🕑 **Date and Time:** {dt_str}",
         f"👥 **Bringing:** {extra_people} extra guest{'s' if extra_people != 1 else ''}",
     ]
+    if attendee_numbers_en:
+        en.append(attendee_numbers_en)
     if extras_names:
         en.append(f"👥 Guest names: {', '.join(extras_names)}")
     if drinks:
@@ -129,6 +158,8 @@ def build_checkin_reminder_message(event: Event, response: Response, rsvp_url: s
         f"🕑 **日時:** {dt_str}",
         f"👥 **同伴者:** {extra_people}名",
     ]
+    if attendee_numbers_jp:
+        jp.append(attendee_numbers_jp)
     if extras_names:
         jp.append(f"👥 同伴者名: {', '.join(extras_names)}")
     if drinks:

--- a/bot/tests/alerts/test_checkin_reminder.py
+++ b/bot/tests/alerts/test_checkin_reminder.py
@@ -51,7 +51,15 @@ def _event(event_dt: datetime | None = None, archived: bool = False) -> Event:
     )
 
 
-def _response(user_id: int, *, extra_people: int = 0, extras_names=None, drinks=None) -> Response:
+def _response(
+    user_id: int,
+    *,
+    extra_people: int = 0,
+    extras_names=None,
+    drinks=None,
+    attendee_number: int | None = None,
+    extras_attendee_numbers=None,
+) -> Response:
     return Response(
         user_id=user_id,
         username=f"user{user_id}",
@@ -63,6 +71,8 @@ def _response(user_id: int, *, extra_people: int = 0, extras_names=None, drinks=
         drinks=drinks or [],
         extras_names=extras_names or [],
         display_name=f"User {user_id}",
+        attendee_number=attendee_number,
+        extras_attendee_numbers=extras_attendee_numbers or [],
     )
 
 
@@ -181,7 +191,35 @@ def test_message_omits_optional_lines_when_empty():
     assert "同伴者名:" not in msg
     assert "Drinks:" not in msg
     assert "飲み物:" not in msg
+    assert "Attendee Number" not in msg
+    assert "受付番号" not in msg
     assert "**Bringing:** 0 extra guests" in msg
+
+
+def test_message_includes_attendee_number_lines():
+    resp = _response(
+        123,
+        extra_people=2,
+        extras_names=["Senpai", "Kouhai"],
+        attendee_number=7,
+        extras_attendee_numbers=[8, 9],
+    )
+
+    msg = build_checkin_reminder_message(_event(), resp, "https://offkai.example/?token=123.abc")
+
+    assert "**Attendee Numbers:** 7 (you), 8 (Senpai), 9 (Kouhai)" in msg
+    assert "**受付番号:** 7（本人）, 8（Senpai）, 9（Kouhai）" in msg
+
+
+def test_message_includes_single_attendee_number_line():
+    msg = build_checkin_reminder_message(
+        _event(),
+        _response(123, attendee_number=7),
+        "https://offkai.example/?token=123.abc",
+    )
+
+    assert "**Attendee Number:** 7 (you)" in msg
+    assert "**受付番号:** 7（本人）" in msg
 
 
 def test_message_omits_qr_lines_when_no_frontend_url():


### PR DESCRIPTION
## Summary
- Show persisted attendee numbers in the 24-hour check-in reminder DM
- Include guest attendee numbers alongside guest names when present
- Keep reminder messages unchanged for older responses without assigned numbers

## Tests
- `uv run ruff check . --fix`
- `uv run ty check`
- `uv run pytest bot\tests`