### PR TITLE
Add stable attendee number reports

### DIFF
--- a/bot/src/offkai_bot/cogs/events.py
+++ b/bot/src/offkai_bot/cogs/events.py
@@ -1,4 +1,5 @@
 import contextlib
+import csv
 import io
 import logging
 import re
@@ -14,6 +15,7 @@ from offkai_bot.alerts.reminders import (
 )
 from offkai_bot.data.event import (
     add_event,
+    add_response_for_event,
     archive_event,
     get_event,
     load_event_data,
@@ -22,13 +24,15 @@ from offkai_bot.data.event import (
     update_event_details,
 )
 from offkai_bot.data.response import (
+    AttendeeReportRow,
     Response,
-    add_response,
+    build_attendee_report_rows,
     calculate_attendance,
     calculate_drinks,
     calculate_waitlist,
     clear_attendee_numbers,
     get_waitlist,
+    has_complete_attendee_numbers,
     promote_specific_from_waitlist,
     remove_response,
     save_responses,
@@ -83,10 +87,48 @@ def _attendance_filename(event_name: str) -> str:
     return f"attendance_{safe_event_name or 'event'}.txt"
 
 
+def _attendance_report_filename(event_name: str) -> str:
+    safe_event_name = re.sub(r"[^A-Za-z0-9._-]+", "_", event_name).strip("._")
+    return f"attendance_report_{safe_event_name or 'event'}.csv"
+
+
 def _attendance_file(event_name: str, output: str) -> discord.File:
     return discord.File(
         fp=io.BytesIO(output.encode("utf-8")),
         filename=_attendance_filename(event_name),
+    )
+
+
+def _attendance_report_file(event_name: str, rows: list[AttendeeReportRow]) -> discord.File:
+    output = io.StringIO(newline="")
+    fieldnames = [
+        "attendee_number",
+        "name",
+        "type",
+        "registered_by_username",
+        "registered_by_display_name",
+        "registered_by_user_id",
+        "guest_index",
+        "drink",
+    ]
+    writer = csv.DictWriter(output, fieldnames=fieldnames, lineterminator="\n")
+    writer.writeheader()
+    for row in rows:
+        writer.writerow(
+            {
+                "attendee_number": row.attendee_number,
+                "name": row.name,
+                "type": row.type,
+                "registered_by_username": row.registered_by_username,
+                "registered_by_display_name": row.registered_by_display_name,
+                "registered_by_user_id": row.registered_by_user_id,
+                "guest_index": row.guest_index if row.guest_index is not None else "",
+                "drink": row.drink,
+            }
+        )
+    return discord.File(
+        fp=io.BytesIO(output.getvalue().encode("utf-8")),
+        filename=_attendance_report_filename(event_name),
     )
 
 
@@ -497,7 +539,7 @@ class EventsCog(commands.Cog):
             extras_names=promoted_entry.extras_names,
             display_name=promoted_entry.display_name,
         )
-        add_response(event_name, promoted_response, force_attendee_number=not event.open)
+        add_response_for_event(event, promoted_response)
 
         if event.role_id and interaction.guild:
             await assign_event_role(interaction.guild, user_id, event.role_id)
@@ -577,6 +619,45 @@ class EventsCog(commands.Cog):
             return
 
         await interaction.response.send_message(output, ephemeral=True)
+
+    @app_commands.command(
+        name="attendance_report",
+        description="Exports attendee numbers for an event as a CSV report.",
+    )
+    @app_commands.describe(event_name="The name of the event.")
+    @app_commands.checks.has_role("Offkai Organizer")
+    @log_command_usage
+    async def attendance_report(self, interaction: discord.Interaction, event_name: str):
+        event = get_event(event_name)
+        if event.open or not has_complete_attendee_numbers(event_name):
+            await interaction.response.send_message(
+                "Attendee numbers are generated when an event is closed. Close the event before exporting this report.",
+                ephemeral=True,
+            )
+            return
+
+        report_rows = build_attendee_report_rows(event_name)
+        try:
+            await interaction.user.send(
+                f"Attendance report for **{event_name}** is attached as a CSV file.",
+                file=_attendance_report_file(event_name, report_rows),
+            )
+            await interaction.response.send_message(
+                f"Attendance report for '{event_name}' has been sent to you by DM.",
+                ephemeral=True,
+            )
+        except (discord.Forbidden, discord.HTTPException, discord.NotFound) as e:
+            _log.warning(
+                "Could not DM attendance report to user %s for event '%s': %s",
+                interaction.user.id,
+                event_name,
+                e,
+            )
+            await interaction.response.send_message(
+                "I couldn't send you a DM, so I've attached the attendance report here.",
+                file=_attendance_report_file(event_name, report_rows),
+                ephemeral=True,
+            )
 
     @app_commands.command(
         name="waitlist",
@@ -704,6 +785,7 @@ class EventsCog(commands.Cog):
     promote.autocomplete("event_name")(offkai_autocomplete_all_non_archived)
     promote.autocomplete("username")(waitlist_user_autocomplete)
     attendance.autocomplete("event_name")(offkai_autocomplete_all_non_archived)
+    attendance_report.autocomplete("event_name")(offkai_autocomplete_all_non_archived)
     waitlist.autocomplete("event_name")(offkai_autocomplete_all_non_archived)
     drinks.autocomplete("event_name")(offkai_autocomplete_all_non_archived)
 

--- a/bot/src/offkai_bot/data/event.py
+++ b/bot/src/offkai_bot/data/event.py
@@ -8,7 +8,7 @@ from datetime import UTC, datetime
 # Use relative imports for sibling modules within the package
 from offkai_bot.config import get_config
 from offkai_bot.data.encoders import DataclassJSONEncoder
-from offkai_bot.data.response import get_responses, get_waitlist
+from offkai_bot.data.response import Response, add_response, get_responses, get_waitlist
 from offkai_bot.errors import (
     CapacityReductionError,
     CapacityReductionWithWaitlistError,
@@ -70,6 +70,7 @@ class Event:
     max_capacity: int | None = None  # None means unlimited capacity
     creator_id: int | None = None  # Discord user ID of the event creator
     closed_attendance_count: int | None = None  # Attendance count when event was closed
+    max_attendee_number: int | None = None  # Highest attendee number assigned after close
     ping_role_id: int | None = None  # Discord role ID to ping in deadline reminders
     role_id: int | None = None  # Discord role ID for event participants
 
@@ -257,6 +258,7 @@ def _load_event_data() -> list[Event]:
                         max_capacity=event_dict.get("max_capacity"),
                         creator_id=event_dict.get("creator_id"),
                         closed_attendance_count=event_dict.get("closed_attendance_count"),
+                        max_attendee_number=event_dict.get("max_attendee_number"),
                         ping_role_id=event_dict.get("ping_role_id"),
                         role_id=event_dict.get("role_id"),
                     )
@@ -279,6 +281,7 @@ def _load_event_data() -> list[Event]:
                         max_capacity=event_dict.get("max_capacity"),
                         creator_id=event_dict.get("creator_id"),
                         closed_attendance_count=event_dict.get("closed_attendance_count"),
+                        max_attendee_number=event_dict.get("max_attendee_number"),
                         ping_role_id=event_dict.get("ping_role_id"),
                         role_id=event_dict.get("role_id"),
                     )
@@ -342,6 +345,23 @@ def save_event_data():
         _log.error("Error writing event data to %s: %s", settings["EVENTS_FILE"], e)
     except Exception as e:
         _log.exception("An unexpected error occurred saving event data: %s", e)
+
+
+def add_response_for_event(event: Event, response: Response) -> int | None:
+    """Add a response using event state to maintain post-close attendee numbering."""
+    attendee_number_start = (
+        event.max_attendee_number + 1 if not event.open and event.max_attendee_number is not None else None
+    )
+    assigned_max_number = add_response(
+        event.event_name,
+        response,
+        force_attendee_number=not event.open,
+        attendee_number_start=attendee_number_start,
+    )
+    if assigned_max_number is not None:
+        event.max_attendee_number = assigned_max_number
+        save_event_data()
+    return assigned_max_number
 
 
 def get_event(event_name: str) -> Event:
@@ -549,6 +569,7 @@ def set_event_open_status(event_name: str, target_open_status: bool) -> Event:
     if target_open_status:
         # Reopening the event - clear the closed attendance count
         event.closed_attendance_count = None
+        event.max_attendee_number = None
         _log.info("Event '%s' reopened, cleared closed_attendance_count.", event_name)
     else:
         # Closing the event - capture current attendance count

--- a/bot/src/offkai_bot/data/event.py
+++ b/bot/src/offkai_bot/data/event.py
@@ -8,7 +8,7 @@ from datetime import UTC, datetime
 # Use relative imports for sibling modules within the package
 from offkai_bot.config import get_config
 from offkai_bot.data.encoders import DataclassJSONEncoder
-from offkai_bot.data.response import Response, add_response, get_responses, get_waitlist
+from offkai_bot.data.response import Response, add_response, get_max_attendee_number, get_responses, get_waitlist
 from offkai_bot.errors import (
     CapacityReductionError,
     CapacityReductionWithWaitlistError,
@@ -349,9 +349,15 @@ def save_event_data():
 
 def add_response_for_event(event: Event, response: Response) -> int | None:
     """Add a response using event state to maintain post-close attendee numbering."""
-    attendee_number_start = (
-        event.max_attendee_number + 1 if not event.open and event.max_attendee_number is not None else None
-    )
+    attendee_number_start = None
+    if not event.open:
+        max_known_attendee_number = max(
+            event.max_attendee_number or 0,
+            event.closed_attendance_count or 0,
+            get_max_attendee_number(event.event_name),
+        )
+        attendee_number_start = max_known_attendee_number + 1
+
     assigned_max_number = add_response(
         event.event_name,
         response,

--- a/bot/src/offkai_bot/data/response.py
+++ b/bot/src/offkai_bot/data/response.py
@@ -119,6 +119,11 @@ def _next_attendee_number(event_data: EventData) -> int:
     return max(assigned_numbers, default=0) + 1
 
 
+def _max_attendee_number(event_data: EventData) -> int:
+    assigned_numbers = [number for response in event_data["attendees"] for number in _group_attendee_numbers(response)]
+    return max(assigned_numbers, default=0)
+
+
 def _assign_group_numbers(response: Response, start_number: int) -> int:
     response.attendee_number = start_number
     response.extras_attendee_numbers = list(range(start_number + 1, start_number + 1 + response.extra_people))
@@ -484,6 +489,13 @@ def get_waitlist(event_name: str) -> list[WaitlistEntry]:
 def has_complete_attendee_numbers(event_name: str) -> bool:
     """Return True when every current attendee slot has a unique stored number."""
     return _has_complete_attendee_numbers(get_responses(event_name))
+
+
+def get_max_attendee_number(event_name: str) -> int:
+    """Return the highest currently stored attendee number for an event."""
+    all_data = load_responses()
+    event_data = all_data.get(event_name, EventData(attendees=[], waitlist=[]))
+    return _max_attendee_number(event_data)
 
 
 def build_attendee_report_rows(event_name: str) -> list[AttendeeReportRow]:

--- a/bot/src/offkai_bot/data/response.py
+++ b/bot/src/offkai_bot/data/response.py
@@ -52,6 +52,18 @@ class WaitlistEntry:
     display_name: str | None = None
 
 
+@dataclass(frozen=True)
+class AttendeeReportRow:
+    attendee_number: int
+    name: str
+    type: str
+    registered_by_username: str
+    registered_by_display_name: str
+    registered_by_user_id: int
+    guest_index: int | None
+    drink: str
+
+
 # --- Type Definitions ---
 class EventData(TypedDict):
     attendees: list[Response]
@@ -118,24 +130,6 @@ def _clear_group_numbers(response: Response) -> None:
     response.extras_attendee_numbers = []
 
 
-def _compact_numbers_after_removal(attendees: list[Response], removed_numbers: list[int]) -> None:
-    if not removed_numbers:
-        return
-
-    sorted_removed = sorted(removed_numbers)
-
-    def compact(number: int | None) -> int | None:
-        if number is None:
-            return None
-        decrement = sum(1 for removed_number in sorted_removed if removed_number < number)
-        return number - decrement
-
-    for response in attendees:
-        response.attendee_number = compact(response.attendee_number)
-        compacted_extras = [compact(number) for number in response.extras_attendee_numbers]
-        response.extras_attendee_numbers = [number for number in compacted_extras if number is not None]
-
-
 def _number_for_extra(response: Response, index: int) -> int | None:
     if index < len(response.extras_attendee_numbers):
         return response.extras_attendee_numbers[index]
@@ -145,7 +139,17 @@ def _number_for_extra(response: Response, index: int) -> int | None:
 def _has_complete_attendee_numbers(responses: list[Response]) -> bool:
     expected_count = sum(1 + response.extra_people for response in responses)
     actual_numbers = [number for response in responses for number in _group_attendee_numbers(response)]
-    return sorted(actual_numbers) == list(range(1, expected_count + 1))
+    return (
+        len(actual_numbers) == expected_count
+        and len(set(actual_numbers)) == expected_count
+        and all(number > 0 for number in actual_numbers)
+    )
+
+
+def _drink_for(response: Response, index: int) -> str:
+    if index < len(response.drinks):
+        return response.drinks[index]
+    return "N/A"
 
 
 def _migrate_old_format_to_new(
@@ -477,7 +481,55 @@ def get_waitlist(event_name: str) -> list[WaitlistEntry]:
     return event_data["waitlist"]
 
 
-def assign_attendee_numbers(event_name: str) -> None:
+def has_complete_attendee_numbers(event_name: str) -> bool:
+    """Return True when every current attendee slot has a unique stored number."""
+    return _has_complete_attendee_numbers(get_responses(event_name))
+
+
+def build_attendee_report_rows(event_name: str) -> list[AttendeeReportRow]:
+    """Build CSV-ready attendee report rows sorted by stored attendee number."""
+    responses = get_responses(event_name)
+    rows: list[AttendeeReportRow] = []
+
+    for response in responses:
+        if response.attendee_number is not None:
+            rows.append(
+                AttendeeReportRow(
+                    attendee_number=response.attendee_number,
+                    name=response.username,
+                    type="primary",
+                    registered_by_username=response.username,
+                    registered_by_display_name=response.display_name or "",
+                    registered_by_user_id=response.user_id,
+                    guest_index=None,
+                    drink=_drink_for(response, 0),
+                )
+            )
+
+        for index in range(response.extra_people):
+            attendee_number = _number_for_extra(response, index)
+            if attendee_number is None:
+                continue
+
+            raw_name = response.extras_names[index] if index < len(response.extras_names) else ""
+            guest_name = raw_name.strip() if isinstance(raw_name, str) else ""
+            rows.append(
+                AttendeeReportRow(
+                    attendee_number=attendee_number,
+                    name=guest_name or f"Guest {index + 1}",
+                    type="guest",
+                    registered_by_username=response.username,
+                    registered_by_display_name=response.display_name or "",
+                    registered_by_user_id=response.user_id,
+                    guest_index=index + 1,
+                    drink=_drink_for(response, index + 1),
+                )
+            )
+
+    return sorted(rows, key=lambda row: row.attendee_number)
+
+
+def assign_attendee_numbers(event_name: str) -> int:
     """Assign close-time attendee numbers for confirmed attendees in the response cache."""
     all_data = load_responses()
     event_data = all_data.get(event_name, EventData(attendees=[], waitlist=[]))
@@ -488,6 +540,7 @@ def assign_attendee_numbers(event_name: str) -> None:
 
     all_data[event_name] = event_data
     _log.info("Assigned attendee numbers for event %s.", event_name)
+    return next_number - 1
 
 
 def clear_attendee_numbers(event_name: str) -> None:
@@ -502,7 +555,13 @@ def clear_attendee_numbers(event_name: str) -> None:
     _log.info("Cleared attendee numbers for event %s.", event_name)
 
 
-def add_response(event_name: str, response: Response, *, force_attendee_number: bool = False) -> None:
+def add_response(
+    event_name: str,
+    response: Response,
+    *,
+    force_attendee_number: bool = False,
+    attendee_number_start: int | None = None,
+) -> int | None:
     """Adds a response to the specified event's attendees.
 
     Raises:
@@ -522,13 +581,16 @@ def add_response(event_name: str, response: Response, *, force_attendee_number: 
         raise DuplicateResponseError(event_name, response.user_id)
 
     # If no duplicate, proceed with adding
+    assigned_max_number = None
     if force_attendee_number or _event_has_attendee_numbers(event_data):
-        _assign_group_numbers(response, _next_attendee_number(event_data))
+        start_number = attendee_number_start if attendee_number_start is not None else _next_attendee_number(event_data)
+        assigned_max_number = _assign_group_numbers(response, start_number) - 1
 
     event_data["attendees"].append(response)
     all_data[event_name] = event_data
     save_responses()
     _log.info("Added response from user %s to event %s.", response.user_id, event_name)
+    return assigned_max_number
 
 
 def remove_response(event_name: str, user_id: int) -> None:
@@ -549,9 +611,7 @@ def remove_response(event_name: str, user_id: int) -> None:
         raise ResponseNotFoundError(event_name, user_id)
     else:
         # Response found and removed, update the cache and save
-        removed_numbers = _group_attendee_numbers(removed_response)
         event_data["attendees"] = [r for r in event_data["attendees"] if r.user_id != user_id]
-        _compact_numbers_after_removal(event_data["attendees"], removed_numbers)
         all_data[event_name] = event_data
         save_responses()
         _log.info("Removed response from user %s for event %s.", user_id, event_name)

--- a/bot/src/offkai_bot/event_actions.py
+++ b/bot/src/offkai_bot/event_actions.py
@@ -51,7 +51,7 @@ async def perform_close_event(client: discord.Client, event_name: str, close_msg
 
     # 1. Update status in data store (raises EventNotFoundError if not found)
     closed_event = set_event_open_status(event_name, target_open_status=False)
-    assign_attendee_numbers(event_name)
+    closed_event.max_attendee_number = assign_attendee_numbers(event_name)
 
     # 2. Save the change
     save_responses()

--- a/bot/src/offkai_bot/interactions.py
+++ b/bot/src/offkai_bot/interactions.py
@@ -5,7 +5,7 @@ from datetime import UTC, datetime
 import discord
 from discord import ui
 
-from offkai_bot.data.event import Event
+from offkai_bot.data.event import Event, add_response_for_event
 from offkai_bot.data.ranking import can_rank_message_sent, decrease_rank, get_rank, mark_achieved_rank, update_rank
 from offkai_bot.data.response import (
     Response,
@@ -168,7 +168,7 @@ async def promote_waitlist_batch(event: Event, client: discord.Client) -> list[i
             extras_names=promoted_entry.extras_names,
             display_name=promoted_entry.display_name,
         )
-        add_response(event.event_name, promoted_response, force_attendee_number=not event.open)
+        add_response_for_event(event, promoted_response)
         promoted_count += 1
         promoted_user_ids.append(promoted_entry.user_id)
 

--- a/bot/tests/commands/test_attendance.py
+++ b/bot/tests/commands/test_attendance.py
@@ -9,7 +9,7 @@ from discord.ext import commands
 
 # Import the function to test and relevant errors/classes
 from offkai_bot.cogs.events import EventsCog, _format_attendance_output
-from offkai_bot.data.response import NumberedAttendeeName
+from offkai_bot.data.response import AttendeeReportRow, NumberedAttendeeName
 from offkai_bot.errors import (
     EventNotFoundError,
     NoResponsesFoundError,
@@ -75,6 +75,17 @@ async def test_format_attendance_output_uses_persisted_attendee_numbers():
     assert output == "**Attendance for Summer Bash**\n\nTotal Attendees: **2**\n\n4. Alice\n5. Bob"
 
 
+async def test_format_attendance_output_preserves_persisted_number_gaps():
+    attendee_list = [
+        NumberedAttendeeName("Alice", 1),
+        NumberedAttendeeName("Bob", 5),
+    ]
+
+    output = _format_attendance_output("Summer Bash", 2, attendee_list)
+
+    assert output == "**Attendance for Summer Bash**\n\nTotal Attendees: **2**\n\n1. Alice\n5. Bob"
+
+
 async def test_format_attendance_output_uses_dynamic_numbers_for_partial_numbering():
     attendee_list = [
         NumberedAttendeeName("Alice", 4),
@@ -133,6 +144,127 @@ async def test_attendance_success(
     mock_interaction.response.send_message.assert_awaited_once_with(expected_output, ephemeral=True)
     # 4. Check logs (optional)
     mock_log.warning.assert_not_called()
+
+
+@patch("offkai_bot.cogs.events.discord.File")
+@patch("offkai_bot.cogs.events.build_attendee_report_rows")
+@patch("offkai_bot.cogs.events.has_complete_attendee_numbers")
+@patch("offkai_bot.cogs.events.get_event")
+async def test_attendance_report_sends_csv_by_dm(
+    mock_get_event,
+    mock_has_complete_numbers,
+    mock_build_rows,
+    mock_discord_file,
+    mock_interaction,
+    mock_event_obj,
+    mock_cog,
+):
+    """Test attendance_report sends a stable attendee-number CSV file by DM."""
+    event_name_target = "Summer Bash"
+    mock_event_obj.open = False
+    mock_get_event.return_value = mock_event_obj
+    mock_has_complete_numbers.return_value = True
+    mock_build_rows.return_value = [
+        AttendeeReportRow(
+            attendee_number=1,
+            name="Alice",
+            type="primary",
+            registered_by_username="Alice",
+            registered_by_display_name="Alice Display",
+            registered_by_user_id=111,
+            guest_index=None,
+            drink="Tea",
+        ),
+        AttendeeReportRow(
+            attendee_number=3,
+            name="Bob Guest",
+            type="guest",
+            registered_by_username="Bob",
+            registered_by_display_name="Bob Display",
+            registered_by_user_id=222,
+            guest_index=1,
+            drink="Soda",
+        ),
+    ]
+    mock_interaction.user.send = AsyncMock()
+    mock_file = MagicMock()
+    mock_discord_file.return_value = mock_file
+
+    await EventsCog.attendance_report.callback(
+        mock_cog,
+        mock_interaction,
+        event_name=event_name_target,
+    )
+
+    mock_get_event.assert_called_once_with(event_name_target)
+    mock_has_complete_numbers.assert_called_once_with(event_name_target)
+    mock_build_rows.assert_called_once_with(event_name_target)
+    mock_discord_file.assert_called_once()
+    assert mock_discord_file.call_args.kwargs["filename"] == "attendance_report_Summer_Bash.csv"
+    assert mock_discord_file.call_args.kwargs["fp"].getvalue() == (
+        b"attendee_number,name,type,registered_by_username,registered_by_display_name,"
+        b"registered_by_user_id,guest_index,drink\n"
+        b"1,Alice,primary,Alice,Alice Display,111,,Tea\n"
+        b"3,Bob Guest,guest,Bob,Bob Display,222,1,Soda\n"
+    )
+    mock_interaction.user.send.assert_awaited_once_with(
+        f"Attendance report for **{event_name_target}** is attached as a CSV file.",
+        file=mock_file,
+    )
+    mock_interaction.response.send_message.assert_awaited_once_with(
+        f"Attendance report for '{event_name_target}' has been sent to you by DM.",
+        ephemeral=True,
+    )
+
+
+@patch("offkai_bot.cogs.events.build_attendee_report_rows")
+@patch("offkai_bot.cogs.events.has_complete_attendee_numbers")
+@patch("offkai_bot.cogs.events.get_event")
+async def test_attendance_report_rejects_open_event(
+    mock_get_event,
+    mock_has_complete_numbers,
+    mock_build_rows,
+    mock_interaction,
+    mock_event_obj,
+    mock_cog,
+):
+    """Test attendance_report rejects events before close-time numbers exist."""
+    mock_event_obj.open = True
+    mock_get_event.return_value = mock_event_obj
+
+    await EventsCog.attendance_report.callback(mock_cog, mock_interaction, event_name="Summer Bash")
+
+    mock_has_complete_numbers.assert_not_called()
+    mock_build_rows.assert_not_called()
+    mock_interaction.response.send_message.assert_awaited_once_with(
+        "Attendee numbers are generated when an event is closed. Close the event before exporting this report.",
+        ephemeral=True,
+    )
+
+
+@patch("offkai_bot.cogs.events.build_attendee_report_rows")
+@patch("offkai_bot.cogs.events.has_complete_attendee_numbers")
+@patch("offkai_bot.cogs.events.get_event")
+async def test_attendance_report_rejects_incomplete_numbering(
+    mock_get_event,
+    mock_has_complete_numbers,
+    mock_build_rows,
+    mock_interaction,
+    mock_event_obj,
+    mock_cog,
+):
+    """Test attendance_report rejects closed events without full stored numbers."""
+    mock_event_obj.open = False
+    mock_get_event.return_value = mock_event_obj
+    mock_has_complete_numbers.return_value = False
+
+    await EventsCog.attendance_report.callback(mock_cog, mock_interaction, event_name="Summer Bash")
+
+    mock_build_rows.assert_not_called()
+    mock_interaction.response.send_message.assert_awaited_once_with(
+        "Attendee numbers are generated when an event is closed. Close the event before exporting this report.",
+        ephemeral=True,
+    )
 
 
 @patch("offkai_bot.cogs.events.calculate_attendance")

--- a/bot/tests/commands/test_closed_attendance_count.py
+++ b/bot/tests/commands/test_closed_attendance_count.py
@@ -139,12 +139,14 @@ def test_reopening_event_clears_closed_attendance_count(event_with_capacity):
     # Close the event
     closed_event = set_event_open_status(event_with_capacity.event_name, target_open_status=False)
     assert closed_event.closed_attendance_count == 30
+    closed_event.max_attendee_number = 30
 
     # Reopen the event
     reopened_event = set_event_open_status(event_with_capacity.event_name, target_open_status=True)
 
     # Verify closed_attendance_count is cleared
     assert reopened_event.closed_attendance_count is None
+    assert reopened_event.max_attendee_number is None
     assert reopened_event.open is True
 
 

--- a/bot/tests/commands/test_promote.py
+++ b/bot/tests/commands/test_promote.py
@@ -74,7 +74,7 @@ def mock_waitlist_entry():
 
 
 @patch("offkai_bot.cogs.events.update_event_message", new_callable=AsyncMock)
-@patch("offkai_bot.cogs.events.add_response")
+@patch("offkai_bot.cogs.events.add_response_for_event")
 @patch("offkai_bot.cogs.events.promote_specific_from_waitlist")
 @patch("offkai_bot.cogs.events.get_event")
 @patch("offkai_bot.cogs.events._log")
@@ -82,7 +82,7 @@ async def test_promote_success(
     mock_log,
     mock_get_event,
     mock_promote_specific,
-    mock_add_response,
+    mock_add_response_for_event,
     mock_update_event_msg,
     mock_interaction,
     mock_event_obj,
@@ -107,10 +107,10 @@ async def test_promote_success(
 
     mock_get_event.assert_called_once_with("Summer Bash")
     mock_promote_specific.assert_called_once_with("Summer Bash", 99999)
-    mock_add_response.assert_called_once()
+    mock_add_response_for_event.assert_called_once()
 
     # Verify the Response was created from the WaitlistEntry
-    added_response = mock_add_response.call_args[0][1]
+    added_response = mock_add_response_for_event.call_args[0][1]
     assert added_response.user_id == 99999
     assert added_response.username == "waitlistuser"
 
@@ -124,7 +124,7 @@ async def test_promote_success(
 
 
 @patch("offkai_bot.cogs.events.update_event_message", new_callable=AsyncMock)
-@patch("offkai_bot.cogs.events.add_response")
+@patch("offkai_bot.cogs.events.add_response_for_event")
 @patch("offkai_bot.cogs.events.promote_specific_from_waitlist")
 @patch("offkai_bot.cogs.events.get_event")
 @patch("offkai_bot.cogs.events._log")
@@ -132,7 +132,7 @@ async def test_promote_dm_failure(
     mock_log,
     mock_get_event,
     mock_promote_specific,
-    mock_add_response,
+    mock_add_response_for_event,
     mock_update_event_msg,
     mock_interaction,
     mock_event_obj,
@@ -157,7 +157,7 @@ async def test_promote_dm_failure(
 
     # Promotion should still succeed
     mock_promote_specific.assert_called_once()
-    mock_add_response.assert_called_once()
+    mock_add_response_for_event.assert_called_once()
     mock_interaction.response.send_message.assert_awaited_once()
     mock_update_event_msg.assert_awaited_once()
 
@@ -191,13 +191,13 @@ async def test_promote_event_not_found(
     mock_interaction.response.send_message.assert_not_awaited()
 
 
-@patch("offkai_bot.cogs.events.add_response")
+@patch("offkai_bot.cogs.events.add_response_for_event")
 @patch("offkai_bot.cogs.events.promote_specific_from_waitlist")
 @patch("offkai_bot.cogs.events.get_event")
 async def test_promote_user_not_on_waitlist(
     mock_get_event,
     mock_promote_specific,
-    mock_add_response,
+    mock_add_response_for_event,
     mock_interaction,
     mock_event_obj,
     prepopulated_event_cache,
@@ -216,7 +216,7 @@ async def test_promote_user_not_on_waitlist(
         )
 
     mock_promote_specific.assert_called_once_with("Summer Bash", 99999)
-    mock_add_response.assert_not_called()
+    mock_add_response_for_event.assert_not_called()
     mock_interaction.response.send_message.assert_not_awaited()
 
 

--- a/bot/tests/data/test_event.py
+++ b/bot/tests/data/test_event.py
@@ -7,6 +7,7 @@ from unittest.mock import mock_open, patch
 import pytest
 from offkai_bot.data.encoders import DataclassJSONEncoder  # Needed for save verification
 from offkai_bot.data.event import JST, OFFKAI_MESSAGE, Event, create_event_message
+from offkai_bot.data.response import EventData, Response
 from offkai_bot.errors import (
     EventAlreadyArchivedError,
     EventAlreadyClosedError,
@@ -22,6 +23,7 @@ from offkai_bot.errors import (
 
 # Import the module we are testing
 from offkai_bot.data import event as event_data
+from offkai_bot.data import response as response_data
 
 # --- Test Data ---
 # Use explicit future dates for reliability
@@ -462,6 +464,37 @@ def test_load_event_data_loads_if_cache_none(sample_event_list):
         events = event_data.load_event_data()
         assert events == sample_event_list
         mock_internal_load.assert_called_once()
+
+
+def test_add_response_for_event_updates_max_attendee_number(mock_paths):
+    """Test closed-event additions advance the event-level attendee number counter."""
+    event = Event(
+        event_name="Numbered Event",
+        venue="Venue",
+        address="Address",
+        google_maps_link="Maps",
+        event_datetime=FUTURE_EVENT_DT,
+        open=False,
+        max_attendee_number=7,
+    )
+    event_data.EVENT_DATA_CACHE = [event]
+    response_data.RESPONSE_DATA_CACHE = {"Numbered Event": EventData(attendees=[], waitlist=[])}
+    response = Response(
+        user_id=123,
+        username="User",
+        extra_people=1,
+        behavior_confirmed=True,
+        arrival_confirmed=True,
+        event_name="Numbered Event",
+        timestamp=TEST_NOW_UTC,
+    )
+
+    assigned_max_number = event_data.add_response_for_event(event, response)
+
+    assert assigned_max_number == 9
+    assert event.max_attendee_number == 9
+    assert response.attendee_number == 8
+    assert response.extras_attendee_numbers == [9]
 
 
 # == save_event_data Tests ==

--- a/bot/tests/data/test_event.py
+++ b/bot/tests/data/test_event.py
@@ -497,6 +497,58 @@ def test_add_response_for_event_updates_max_attendee_number(mock_paths):
     assert response.extras_attendee_numbers == [9]
 
 
+def test_add_response_for_legacy_closed_event_uses_closed_count_after_highest_withdraws(mock_paths):
+    """Test legacy closed events do not reuse the highest withdrawn attendee number."""
+    event = Event(
+        event_name="Legacy Numbered Event",
+        venue="Venue",
+        address="Address",
+        google_maps_link="Maps",
+        event_datetime=FUTURE_EVENT_DT,
+        open=False,
+        closed_attendance_count=3,
+        max_attendee_number=None,
+    )
+    first = Response(
+        user_id=1,
+        username="First",
+        extra_people=0,
+        behavior_confirmed=True,
+        arrival_confirmed=True,
+        event_name=event.event_name,
+        timestamp=TEST_NOW_UTC,
+        attendee_number=1,
+    )
+    second = Response(
+        user_id=2,
+        username="Second",
+        extra_people=0,
+        behavior_confirmed=True,
+        arrival_confirmed=True,
+        event_name=event.event_name,
+        timestamp=TEST_NOW_UTC,
+        attendee_number=2,
+    )
+    event_data.EVENT_DATA_CACHE = [event]
+    response_data.RESPONSE_DATA_CACHE = {"Legacy Numbered Event": EventData(attendees=[first, second], waitlist=[])}
+    promoted = Response(
+        user_id=4,
+        username="Promoted",
+        extra_people=0,
+        behavior_confirmed=True,
+        arrival_confirmed=True,
+        event_name=event.event_name,
+        timestamp=TEST_NOW_UTC,
+    )
+
+    assigned_max_number = event_data.add_response_for_event(event, promoted)
+
+    assert assigned_max_number == 4
+    assert event.max_attendee_number == 4
+    assert promoted.attendee_number == 4
+    assert [response.attendee_number for response in response_data.get_responses(event.event_name)] == [1, 2, 4]
+
+
 # == save_event_data Tests ==
 
 

--- a/bot/tests/data/test_response.py
+++ b/bot/tests/data/test_response.py
@@ -1638,12 +1638,13 @@ def test_assign_attendee_numbers_sorts_by_username_and_user_id_with_extras(mock_
     )
     response_data.RESPONSE_DATA_CACHE = {"Event N": make_event_data([bob, alice_with_guests, alice_tie])}
 
-    response_data.assign_attendee_numbers("Event N")
+    max_attendee_number = response_data.assign_attendee_numbers("Event N")
 
     assert alice_tie.attendee_number == 1
     assert alice_with_guests.attendee_number == 2
     assert alice_with_guests.extras_attendee_numbers == [3, 4]
     assert bob.attendee_number == 5
+    assert max_attendee_number == 5
 
 
 def test_add_response_appends_attendee_numbers_for_numbered_event(mock_paths):
@@ -1670,10 +1671,11 @@ def test_add_response_appends_attendee_numbers_for_numbered_event(mock_paths):
         timestamp=NOW,
     )
 
-    response_data.add_response("Event N", added)
+    assigned_max_number = response_data.add_response("Event N", added)
 
     assert added.attendee_number == 3
     assert added.extras_attendee_numbers == [4, 5]
+    assert assigned_max_number == 5
 
 
 def test_add_response_can_force_attendee_numbers_for_empty_closed_event(mock_paths):
@@ -1689,14 +1691,15 @@ def test_add_response_can_force_attendee_numbers_for_empty_closed_event(mock_pat
         timestamp=NOW,
     )
 
-    response_data.add_response("Event N", added, force_attendee_number=True)
+    assigned_max_number = response_data.add_response("Event N", added, force_attendee_number=True)
 
     assert added.attendee_number == 1
     assert added.extras_attendee_numbers == [2]
+    assert assigned_max_number == 2
 
 
-def test_remove_response_compacts_later_attendee_numbers_by_group_size(mock_paths):
-    """Test removing a numbered response with guests compacts later numbers."""
+def test_remove_response_preserves_later_attendee_numbers(mock_paths):
+    """Test removing a numbered response with guests leaves later numbers unchanged."""
     first = Response(
         user_id=1,
         username="First",
@@ -1735,8 +1738,38 @@ def test_remove_response_compacts_later_attendee_numbers_by_group_size(mock_path
 
     assert response_data.get_responses("Event N") == [first, later]
     assert first.attendee_number == 1
-    assert later.attendee_number == 2
-    assert later.extras_attendee_numbers == [3]
+    assert later.attendee_number == 5
+    assert later.extras_attendee_numbers == [6]
+
+
+def test_add_response_uses_explicit_attendee_number_start(mock_paths):
+    """Test post-close numbering can start after an event-level max with gaps."""
+    existing = Response(
+        user_id=1,
+        username="Existing",
+        extra_people=0,
+        behavior_confirmed=True,
+        arrival_confirmed=True,
+        event_name="Event N",
+        timestamp=NOW,
+        attendee_number=1,
+    )
+    response_data.RESPONSE_DATA_CACHE = {"Event N": make_event_data([existing])}
+    added = Response(
+        user_id=2,
+        username="Added",
+        extra_people=1,
+        behavior_confirmed=True,
+        arrival_confirmed=True,
+        event_name="Event N",
+        timestamp=NOW,
+    )
+
+    assigned_max_number = response_data.add_response("Event N", added, attendee_number_start=8)
+
+    assert added.attendee_number == 8
+    assert added.extras_attendee_numbers == [9]
+    assert assigned_max_number == 9
 
 
 def test_clear_attendee_numbers_removes_all_numbers(mock_paths):
@@ -1791,3 +1824,81 @@ def test_calculate_attendance_uses_stored_number_order(mock_paths):
     assert total_count == 3
     assert attendee_names == ["First", "Later", "Guest (First +1)"]
     assert [getattr(name, "attendee_number") for name in attendee_names] == [1, 2, 3]
+
+
+def test_calculate_attendance_uses_stored_number_order_with_gaps(mock_paths):
+    """Test numbered closed events preserve gaps instead of falling back to dynamic numbering."""
+    later = Response(
+        user_id=2,
+        username="Later",
+        extra_people=1,
+        behavior_confirmed=True,
+        arrival_confirmed=True,
+        event_name="Event N",
+        timestamp=NOW,
+        attendee_number=5,
+        extras_attendee_numbers=[6],
+    )
+    first = Response(
+        user_id=1,
+        username="First",
+        extra_people=0,
+        behavior_confirmed=True,
+        arrival_confirmed=True,
+        event_name="Event N",
+        timestamp=NOW,
+        attendee_number=1,
+    )
+    response_data.RESPONSE_DATA_CACHE = {"Event N": make_event_data([later, first])}
+
+    total_count, attendee_names = response_data.calculate_attendance("Event N")
+
+    assert total_count == 3
+    assert attendee_names == ["First", "Later", "  (Later +1)"]
+    assert [getattr(name, "attendee_number") for name in attendee_names] == [1, 5, 6]
+
+
+def test_build_attendee_report_rows_sorts_by_attendee_number(mock_paths):
+    """Test CSV report rows include primary and guest audit fields with number gaps."""
+    later = Response(
+        user_id=2,
+        username="Later",
+        extra_people=1,
+        behavior_confirmed=True,
+        arrival_confirmed=True,
+        event_name="Event N",
+        timestamp=NOW,
+        drinks=["Tea", "Soda"],
+        extras_names=["Guest Later"],
+        display_name="LaterDisplay",
+        attendee_number=5,
+        extras_attendee_numbers=[6],
+    )
+    first = Response(
+        user_id=1,
+        username="First",
+        extra_people=0,
+        behavior_confirmed=True,
+        arrival_confirmed=True,
+        event_name="Event N",
+        timestamp=NOW,
+        drinks=["Water"],
+        display_name="FirstDisplay",
+        attendee_number=1,
+    )
+    response_data.RESPONSE_DATA_CACHE = {"Event N": make_event_data([later, first])}
+
+    rows = response_data.build_attendee_report_rows("Event N")
+
+    assert [row.attendee_number for row in rows] == [1, 5, 6]
+    assert rows[0].name == "First"
+    assert rows[0].type == "primary"
+    assert rows[0].registered_by_display_name == "FirstDisplay"
+    assert rows[0].guest_index is None
+    assert rows[0].drink == "Water"
+    assert rows[2].name == "Guest Later"
+    assert rows[2].type == "guest"
+    assert rows[2].registered_by_username == "Later"
+    assert rows[2].registered_by_user_id == 2
+    assert rows[2].guest_index == 1
+    assert rows[2].drink == "Soda"

--- a/bot/tests/test_event_actions.py
+++ b/bot/tests/test_event_actions.py
@@ -212,11 +212,13 @@ async def test_send_event_message_raises_on_pin_failure(
 @patch("offkai_bot.event_actions.fetch_thread_for_event", new_callable=AsyncMock)
 @patch("offkai_bot.event_actions.update_event_message", new_callable=AsyncMock)
 @patch("offkai_bot.event_actions.save_event_data")
+@patch("offkai_bot.event_actions.assign_attendee_numbers")
 @patch("offkai_bot.event_actions.set_event_open_status")
 @patch("offkai_bot.event_actions._log")
 async def test_perform_close_event_success_with_message(
     mock_log,
     mock_set_status,
+    mock_assign_attendee_numbers,
     mock_save_data,
     mock_update_msg_view,
     mock_fetch_thread,
@@ -230,6 +232,7 @@ async def test_perform_close_event_success_with_message(
     event_name_to_close = "Summer Bash"
     close_text = "Responses are now closed!"
     mock_set_status.return_value = mock_closed_event
+    mock_assign_attendee_numbers.return_value = 42
     mock_fetch_thread.return_value = mock_thread
     mock_thread.id = mock_closed_event.thread_id
     mock_thread.mention = f"<#{mock_thread.id}>"
@@ -244,6 +247,8 @@ async def test_perform_close_event_success_with_message(
     # Assert
     assert result == mock_closed_event
     mock_set_status.assert_called_once_with(event_name_to_close, target_open_status=False)
+    mock_assign_attendee_numbers.assert_called_once_with(event_name_to_close)
+    assert mock_closed_event.max_attendee_number == 42
     mock_save_data.assert_called_once()
     mock_update_msg_view.assert_awaited_once_with(mock_client, mock_closed_event)
     mock_fetch_thread.assert_awaited_once_with(mock_client, mock_closed_event)
@@ -255,11 +260,13 @@ async def test_perform_close_event_success_with_message(
 @patch("offkai_bot.event_actions.fetch_thread_for_event", new_callable=AsyncMock)
 @patch("offkai_bot.event_actions.update_event_message", new_callable=AsyncMock)
 @patch("offkai_bot.event_actions.save_event_data")
+@patch("offkai_bot.event_actions.assign_attendee_numbers")
 @patch("offkai_bot.event_actions.set_event_open_status")
 @patch("offkai_bot.event_actions._log")
 async def test_perform_close_event_success_no_message(
     mock_log,
     mock_set_status,
+    mock_assign_attendee_numbers,
     mock_save_data,
     mock_update_msg_view,
     mock_fetch_thread,
@@ -272,6 +279,7 @@ async def test_perform_close_event_success_no_message(
     # Arrange
     event_name_to_close = "Summer Bash"
     mock_set_status.return_value = mock_closed_event
+    mock_assign_attendee_numbers.return_value = 42
 
     # Act
     result = await perform_close_event(
@@ -283,6 +291,8 @@ async def test_perform_close_event_success_no_message(
     # Assert
     assert result == mock_closed_event
     mock_set_status.assert_called_once_with(event_name_to_close, target_open_status=False)
+    mock_assign_attendee_numbers.assert_called_once_with(event_name_to_close)
+    assert mock_closed_event.max_attendee_number == 42
     mock_save_data.assert_called_once()
     mock_update_msg_view.assert_awaited_once_with(mock_client, mock_closed_event)
     mock_fetch_thread.assert_not_awaited()


### PR DESCRIPTION
## Summary
- preserve attendee number gaps when attendees unregister or responses are deleted
- track the highest assigned attendee number after close so post-close promotions do not reuse numbers
- add `/attendance_report` to export a CSV sorted by stored attendee numbers

## Verification
- `uv run ruff check . --fix`
- `uv run ty check`
- `uv run pytest bot\tests`

Note: local untracked `AGENTS.md` was intentionally left out of this PR.