### PR TITLE
Fix unbound/stale event_datetime_utc in event loader

### DIFF
--- a/bot/src/offkai_bot/data/event.py
+++ b/bot/src/offkai_bot/data/event.py
@@ -179,6 +179,7 @@ def _load_event_data() -> list[Event]:
                 continue  # Skip this dictionary and move to the next one
 
             # --- Parse and Convert event_datetime ---
+            event_datetime_utc = None
             raw_dt_str = event_dict.get("event_datetime")
             if raw_dt_str:
                 try:
@@ -203,8 +204,10 @@ def _load_event_data() -> list[Event]:
                         event_dict.get("event_name"),
                         e,
                     )
-                    _log.error("Skipping event entry due to missing or empty 'event_datetime'. Data: %s", event_dict)
-                    continue
+
+            if event_datetime_utc is None:
+                _log.error("Skipping event entry due to missing or empty 'event_datetime'. Data: %s", event_dict)
+                continue
             # --- End event_datetime Parsing ---
 
             # --- Parse and Convert event_deadline ---

--- a/bot/tests/data/test_event.py
+++ b/bot/tests/data/test_event.py
@@ -278,6 +278,63 @@ def test_load_event_data_invalid_datetime(mock_paths):
         assert mock_log.warning.call_args[0][1] == "not-a-datetime"
 
 
+def test_load_event_data_missing_datetime(mock_paths):
+    """Test loading data where an entry is missing 'event_datetime' entirely.
+
+    Regression test: a missing datetime must not leave `event_datetime_utc`
+    unbound (NameError -> whole load fails) or stale from a prior iteration.
+    """
+    dt1 = datetime(2024, 8, 1, 19, 0, tzinfo=UTC)
+    missing_dt_event = {"event_name": "Missing DT", "venue": "V", "address": "A", "google_maps_link": "G"}
+    valid_event_dict = {
+        "event_name": "Valid Event",
+        "venue": "V",
+        "address": "A",
+        "google_maps_link": "G",
+        "event_datetime": dt1.isoformat(),
+    }
+    bad_json = json.dumps([missing_dt_event, valid_event_dict])
+
+    with (
+        patch("os.path.exists", return_value=True),
+        patch("os.path.getsize", return_value=100),
+        patch("builtins.open", mock_open(read_data=bad_json)),
+        patch("offkai_bot.data.event._log") as mock_log,
+    ):
+        events = event_data._load_event_data()
+
+        assert len(events) == 1
+        assert events[0].event_name == "Valid Event"
+        assert events[0].event_datetime == dt1
+        mock_log.error.assert_called_once()
+        assert "Skipping event entry due to missing or empty 'event_datetime'." in mock_log.error.call_args[0][0]
+
+
+def test_load_event_data_empty_datetime(mock_paths):
+    """Test loading data where 'event_datetime' is an empty string."""
+    empty_dt_event = {
+        "event_name": "Empty DT",
+        "venue": "V",
+        "address": "A",
+        "google_maps_link": "G",
+        "event_datetime": "",
+    }
+    bad_json = json.dumps([empty_dt_event])
+
+    with (
+        patch("os.path.exists", return_value=True),
+        patch("os.path.getsize", return_value=100),
+        patch("builtins.open", mock_open(read_data=bad_json)),
+        patch("offkai_bot.data.event._log") as mock_log,
+    ):
+        events = event_data._load_event_data()
+
+        assert events == []
+        assert event_data.EVENT_DATA_CACHE == []
+        mock_log.error.assert_called_once()
+        assert "Skipping event entry due to missing or empty 'event_datetime'." in mock_log.error.call_args[0][0]
+
+
 def test_load_event_data_with_ping_role_id(mock_paths):
     """Test loading event data that includes a ping_role_id field."""
     dt1 = datetime(2024, 8, 1, 19, 0, tzinfo=UTC)


### PR DESCRIPTION
## Summary
- `_load_event_data` in `bot/src/offkai_bot/data/event.py` only assigned `event_datetime_utc` inside `if raw_dt_str:`, with no `else`/`continue`. An entry missing/empty `event_datetime` left the variable unbound (first such entry → `NameError`, caught by the blanket `except Exception`, which zeroes `EVENT_DATA_CACHE` and can wipe `events.json` on the next save) or stale from the previous loop iteration (later entries silently inherit another event's datetime).
- Fixed by initializing `event_datetime_utc = None` before the parse attempt and skipping the entry (with an error log) if it's still `None` afterward — mirroring the existing guard already used for `event_deadline_utc`.

## Test plan
- [x] Added `test_load_event_data_missing_datetime` — entry missing `event_datetime` is skipped, doesn't corrupt/crash the load of a subsequent valid entry.
- [x] Added `test_load_event_data_empty_datetime` — entry with `event_datetime: ""` is skipped.
- [x] `uv run pytest bot/tests` — 505 passed
- [x] `uvx ruff check --fix .` — clean
- [x] `uvx ty check` — clean

Fixes #95

🤖 Generated with [Claude Code](https://claude.com/claude-code)