### PR TITLE
Make JSON data saves atomic and preserve corrupted files before overwrite

### DIFF
--- a/bot/src/offkai_bot/data/atomic.py
+++ b/bot/src/offkai_bot/data/atomic.py
@@ -1,0 +1,53 @@
+# src/offkai_bot/data/atomic.py
+import contextlib
+import json
+import logging
+import os
+import shutil
+import tempfile
+from datetime import UTC, datetime
+
+_log = logging.getLogger(__name__)
+
+
+def atomic_write_json(file_path: str, data: object, **json_kwargs) -> None:
+    """
+    Writes `data` to `file_path` as JSON atomically.
+
+    Writes to a temp file in the same directory, flushes and fsyncs it, then
+    uses os.replace() to swap it into place. os.replace() is atomic on both
+    POSIX and Windows, so a crash or power loss mid-write can never leave
+    `file_path` truncated or partially written.
+    """
+    directory = os.path.dirname(file_path) or "."
+    fd, tmp_path = tempfile.mkstemp(dir=directory, prefix=f"{os.path.basename(file_path)}.", suffix=".tmp")
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as file:
+            json.dump(data, file, **json_kwargs)
+            file.flush()
+            os.fsync(file.fileno())
+        os.replace(tmp_path, file_path)
+    except BaseException:
+        with contextlib.suppress(OSError):
+            os.remove(tmp_path)
+        raise
+
+
+def backup_corrupted_file(file_path: str) -> None:
+    """
+    Preserves a data file that failed to parse before it can be silently
+    overwritten by the next save.
+
+    Without this, a load failure resets the in-memory cache to empty and the
+    next save destroys the corrupted-but-possibly-recoverable file for good.
+    """
+    if not os.path.exists(file_path):
+        return
+
+    timestamp = datetime.now(UTC).strftime("%Y%m%d%H%M%S")
+    backup_path = f"{file_path}.corrupted-{timestamp}.bak"
+    try:
+        shutil.copy2(file_path, backup_path)
+        _log.warning("Backed up unparseable file %s to %s before it could be overwritten.", file_path, backup_path)
+    except OSError as e:
+        _log.error("Could not back up unparseable file %s: %s", file_path, e)

--- a/bot/src/offkai_bot/data/event.py
+++ b/bot/src/offkai_bot/data/event.py
@@ -7,6 +7,7 @@ from datetime import UTC, datetime
 
 # Use relative imports for sibling modules within the package
 from offkai_bot.config import get_config
+from offkai_bot.data.atomic import atomic_write_json, backup_corrupted_file
 from offkai_bot.data.encoders import DataclassJSONEncoder
 from offkai_bot.data.response import get_responses, get_waitlist
 from offkai_bot.errors import (
@@ -302,6 +303,7 @@ def _load_event_data() -> list[Event]:
         return []
     except json.JSONDecodeError:
         _log.error("Error decoding JSON from %s. File might be corrupted or invalid. Loading empty list.", file_path)
+        backup_corrupted_file(file_path)
         EVENT_DATA_CACHE = []
         return []
     except Exception as e:
@@ -330,14 +332,13 @@ def save_event_data():
         return
 
     try:
-        with open(settings["EVENTS_FILE"], "w", encoding="utf-8") as file:
-            json.dump(
-                EVENT_DATA_CACHE,
-                file,
-                indent=4,
-                cls=DataclassJSONEncoder,
-                ensure_ascii=False,
-            )
+        atomic_write_json(
+            settings["EVENTS_FILE"],
+            EVENT_DATA_CACHE,
+            indent=4,
+            cls=DataclassJSONEncoder,
+            ensure_ascii=False,
+        )
     except OSError as e:
         _log.error("Error writing event data to %s: %s", settings["EVENTS_FILE"], e)
     except Exception as e:

--- a/bot/src/offkai_bot/data/ranking.py
+++ b/bot/src/offkai_bot/data/ranking.py
@@ -5,6 +5,7 @@ import os
 from dataclasses import dataclass
 
 from offkai_bot.config import get_config
+from offkai_bot.data.atomic import atomic_write_json, backup_corrupted_file
 from offkai_bot.data.encoders import DataclassJSONEncoder
 
 _log = logging.getLogger(__name__)
@@ -93,6 +94,7 @@ def _load_rankings() -> dict[str, UserRank]:
         _log.error(
             "Error decoding JSON from %s. File might be corrupted or invalid. Loading empty responses.", file_path
         )
+        backup_corrupted_file(file_path)
         RANKING_DATA_CACHE = {}
         return {}
     except Exception as e:
@@ -120,14 +122,13 @@ def save_rankings():
         return
 
     try:
-        with open(settings["RANKING_FILE"], "w", encoding="utf-8") as file:
-            json.dump(
-                RANKING_DATA_CACHE,
-                file,
-                indent=4,
-                cls=DataclassJSONEncoder,
-                ensure_ascii=False,
-            )
+        atomic_write_json(
+            settings["RANKING_FILE"],
+            RANKING_DATA_CACHE,
+            indent=4,
+            cls=DataclassJSONEncoder,
+            ensure_ascii=False,
+        )
     except OSError as e:
         _log.error("Error writing response data to %s: %s", settings["RANKING_FILE"], e)
     except Exception as e:

--- a/bot/src/offkai_bot/data/response.py
+++ b/bot/src/offkai_bot/data/response.py
@@ -9,6 +9,7 @@ from typing import TypedDict
 
 # Use relative imports for sibling modules within the package
 from offkai_bot.config import get_config
+from offkai_bot.data.atomic import atomic_write_json, backup_corrupted_file
 from offkai_bot.data.encoders import DataclassJSONEncoder
 from offkai_bot.errors import (
     DuplicateResponseError,
@@ -421,6 +422,7 @@ def _load_responses() -> dict[str, EventData]:
         _log.error(
             "Error decoding JSON from %s. File might be corrupted or invalid. Loading empty responses.", file_path
         )
+        backup_corrupted_file(file_path)
         RESPONSE_DATA_CACHE = {}
         return {}
     except Exception as e:
@@ -449,14 +451,13 @@ def save_responses():
         return
 
     try:
-        with open(settings["RESPONSES_FILE"], "w", encoding="utf-8") as file:
-            json.dump(
-                RESPONSE_DATA_CACHE,
-                file,
-                indent=4,
-                cls=DataclassJSONEncoder,
-                ensure_ascii=False,
-            )
+        atomic_write_json(
+            settings["RESPONSES_FILE"],
+            RESPONSE_DATA_CACHE,
+            indent=4,
+            cls=DataclassJSONEncoder,
+            ensure_ascii=False,
+        )
     except OSError as e:
         _log.error("Error writing response data to %s: %s", settings["RESPONSES_FILE"], e)
     except Exception as e:

--- a/bot/tests/data/test_atomic.py
+++ b/bot/tests/data/test_atomic.py
@@ -1,0 +1,116 @@
+# tests/data/test_atomic.py
+import glob
+import os
+from unittest.mock import patch
+
+import pytest
+
+from offkai_bot.data import atomic
+
+
+def test_atomic_write_json_writes_data(tmp_path):
+    """Data written via atomic_write_json can be read back correctly."""
+    target = tmp_path / "data.json"
+
+    atomic.atomic_write_json(str(target), {"a": 1, "b": [1, 2, 3]}, indent=4)
+
+    assert target.exists()
+    expected = '{\n    "a": 1,\n    "b": [\n        1,\n        2,\n        3\n    ]\n}'
+    assert target.read_text(encoding="utf-8") == expected
+
+
+def test_atomic_write_json_no_leftover_temp_files(tmp_path):
+    """No .tmp files should remain in the directory after a successful write."""
+    target = tmp_path / "data.json"
+
+    atomic.atomic_write_json(str(target), {"a": 1})
+
+    leftovers = glob.glob(str(tmp_path / "*.tmp"))
+    assert leftovers == []
+
+
+def test_atomic_write_json_preserves_original_on_dump_failure(tmp_path):
+    """If json.dump fails mid-write, the original file must be untouched and the temp file cleaned up."""
+    target = tmp_path / "data.json"
+    target.write_text("original content", encoding="utf-8")
+
+    class Unserializable:
+        pass
+
+    with pytest.raises(TypeError):
+        atomic.atomic_write_json(str(target), {"bad": Unserializable()})
+
+    assert target.read_text(encoding="utf-8") == "original content"
+    leftovers = glob.glob(str(tmp_path / "*.tmp"))
+    assert leftovers == []
+
+
+def test_atomic_write_json_replaces_existing_file(tmp_path):
+    """A pre-existing target file is fully replaced by the new content."""
+    target = tmp_path / "data.json"
+    target.write_text('{"old": true}', encoding="utf-8")
+
+    atomic.atomic_write_json(str(target), {"new": True})
+
+    assert target.read_text(encoding="utf-8") == '{"new": true}'
+
+
+def test_backup_corrupted_file_creates_copy(tmp_path):
+    """A corrupted file is copied aside before it would be overwritten."""
+    target = tmp_path / "data.json"
+    target.write_text("not valid json", encoding="utf-8")
+
+    atomic.backup_corrupted_file(str(target))
+
+    backups = glob.glob(str(tmp_path / "data.json.corrupted-*.bak"))
+    assert len(backups) == 1
+    with open(backups[0], encoding="utf-8") as backup_file:
+        assert backup_file.read() == "not valid json"
+    # Original file is left in place too.
+    assert target.read_text(encoding="utf-8") == "not valid json"
+
+
+def test_backup_corrupted_file_missing_file_is_noop(tmp_path):
+    """Backing up a nonexistent file should do nothing and not raise."""
+    target = tmp_path / "does_not_exist.json"
+
+    atomic.backup_corrupted_file(str(target))
+
+    assert glob.glob(str(tmp_path / "*.bak")) == []
+
+
+def test_backup_corrupted_file_logs_on_os_error(tmp_path):
+    """An OSError while copying is logged, not raised."""
+    target = tmp_path / "data.json"
+    target.write_text("not valid json", encoding="utf-8")
+
+    with (
+        patch("shutil.copy2", side_effect=OSError("disk full")),
+        patch("offkai_bot.data.atomic._log") as mock_log,
+    ):
+        atomic.backup_corrupted_file(str(target))
+
+    mock_log.error.assert_called_once()
+    assert "Could not back up" in mock_log.error.call_args[0][0]
+
+
+def test_backup_corrupted_file_uses_same_directory(tmp_path):
+    """The temp file used during atomic_write_json lives in the target's directory (so os.replace stays atomic)."""
+    target = tmp_path / "data.json"
+
+    original_mkstemp = None
+    captured = {}
+
+    import tempfile as tempfile_module
+
+    original_mkstemp = tempfile_module.mkstemp
+
+    def spy_mkstemp(*args, **kwargs):
+        result = original_mkstemp(*args, **kwargs)
+        captured["dir"] = kwargs.get("dir")
+        return result
+
+    with patch("tempfile.mkstemp", side_effect=spy_mkstemp):
+        atomic.atomic_write_json(str(target), {"a": 1})
+
+    assert os.path.normpath(captured["dir"]) == os.path.normpath(str(tmp_path))

--- a/bot/tests/data/test_event.py
+++ b/bot/tests/data/test_event.py
@@ -233,6 +233,7 @@ def test_load_event_data_json_decode_error(mock_paths):
         patch("os.path.getsize", return_value=100),
         patch("builtins.open", mock_open(read_data="invalid json")),
         patch("offkai_bot.data.event._log") as mock_log,
+        patch("offkai_bot.data.event.backup_corrupted_file") as mock_backup,
     ):
         events = event_data._load_event_data()
 
@@ -240,6 +241,7 @@ def test_load_event_data_json_decode_error(mock_paths):
         assert event_data.EVENT_DATA_CACHE == []
         mock_log.error.assert_called_once()
         assert "Error decoding JSON" in mock_log.error.call_args[0][0]
+        mock_backup.assert_called_once_with(mock_paths["events"])
 
 
 def test_load_event_data_not_a_list(mock_paths):
@@ -471,33 +473,19 @@ def test_save_event_data_success(mock_paths, sample_event_list):
     """Test saving valid event data."""
     event_data.EVENT_DATA_CACHE = sample_event_list  # Populate cache
 
-    m_open = mock_open()
-    # Patch both open and json.dump
     with (
-        patch("builtins.open", m_open) as mock_file_constructor,
-        patch("json.dump") as mock_json_dump,
+        patch("offkai_bot.data.event.atomic_write_json") as mock_atomic_write,
         patch("offkai_bot.data.event._log") as mock_log,
     ):
         event_data.save_event_data()
 
-        # 1. Check file was opened correctly
-        mock_file_constructor.assert_called_once_with(mock_paths["events"], "w", encoding="utf-8")
+        # Check atomic_write_json was called correctly
+        mock_atomic_write.assert_called_once()
+        args, kwargs = mock_atomic_write.call_args
 
-        # 2. Get the mock file handle that *should* have been passed to json.dump
-        #    mock_open returns the same mock handle every time it's called within the context
-        mock_file_handle = m_open()
+        assert args[0] == mock_paths["events"]
+        assert args[1] == event_data.EVENT_DATA_CACHE
 
-        # 3. Check json.dump was called correctly
-        mock_json_dump.assert_called_once()
-        args, kwargs = mock_json_dump.call_args
-
-        # Check the positional arguments passed to json.dump
-        # args[0] should be the data to dump
-        assert args[0] == event_data.EVENT_DATA_CACHE
-        # args[1] should be the file handle
-        assert args[1] is mock_file_handle  # Check it's the handle returned by mock_open
-
-        # Check the keyword arguments passed to json.dump
         assert kwargs.get("indent") == 4
         assert kwargs.get("cls") == DataclassJSONEncoder
         assert kwargs.get("ensure_ascii") is False  # Use 'is False' for explicit boolean check
@@ -510,10 +498,13 @@ def test_save_event_data_cache_is_none(mock_paths):
     """Test saving when cache hasn't been loaded."""
     assert event_data.EVENT_DATA_CACHE is None
 
-    with patch("builtins.open") as mock_file_constructor, patch("offkai_bot.data.event._log") as mock_log:
+    with (
+        patch("offkai_bot.data.event.atomic_write_json") as mock_atomic_write,
+        patch("offkai_bot.data.event._log") as mock_log,
+    ):
         event_data.save_event_data()
 
-        mock_file_constructor.assert_not_called()  # Should not attempt to open file
+        mock_atomic_write.assert_not_called()  # Should not attempt to write file
         mock_log.error.assert_called_once()
         assert "Attempted to save event data before loading" in mock_log.error.call_args[0][0]
 
@@ -521,10 +512,11 @@ def test_save_event_data_cache_is_none(mock_paths):
 def test_save_event_data_os_error(mock_paths, sample_event_list):
     """Test handling OS error during file writing."""
     event_data.EVENT_DATA_CACHE = sample_event_list  # Populate cache
-    m_open = mock_open()
-    m_open.side_effect = OSError("Disk full")  # Simulate error on open('w')
 
-    with patch("builtins.open", m_open), patch("offkai_bot.data.event._log") as mock_log:
+    with (
+        patch("offkai_bot.data.event.atomic_write_json", side_effect=OSError("Disk full")),
+        patch("offkai_bot.data.event._log") as mock_log,
+    ):
         event_data.save_event_data()
 
         mock_log.error.assert_called_once()

--- a/bot/tests/data/test_ranking.py
+++ b/bot/tests/data/test_ranking.py
@@ -236,6 +236,7 @@ def test_load_rankings_json_decode_error(mock_paths):
         patch("os.path.getsize", return_value=100),
         patch("builtins.open", mock_open(read_data="invalid json")),
         patch("offkai_bot.data.ranking._log") as mock_log,
+        patch("offkai_bot.data.ranking.backup_corrupted_file") as mock_backup,
     ):
         rankings = ranking_data._load_rankings()
 
@@ -243,6 +244,7 @@ def test_load_rankings_json_decode_error(mock_paths):
         assert ranking_data.RANKING_DATA_CACHE == {}
         mock_log.error.assert_called_once()
         assert "Error decoding JSON" in mock_log.error.call_args[0][0]
+        mock_backup.assert_called_once_with(mock_paths["ranking"])
 
 
 def test_load_rankings_not_a_dict(mock_paths):
@@ -310,22 +312,17 @@ def test_save_rankings_success(mock_paths):
         "User2": RANK_5_OBJ,
     }
 
-    m_open = mock_open()
     with (
-        patch("builtins.open", m_open) as mock_file_constructor,
-        patch("json.dump") as mock_json_dump,
+        patch("offkai_bot.data.ranking.atomic_write_json") as mock_atomic_write,
         patch("offkai_bot.data.ranking._log") as mock_log,
     ):
         ranking_data.save_rankings()
 
-        mock_file_constructor.assert_called_once_with(mock_paths["ranking"], "w", encoding="utf-8")
+        mock_atomic_write.assert_called_once()
+        args, kwargs = mock_atomic_write.call_args
 
-        mock_file_handle = m_open()
-        mock_json_dump.assert_called_once()
-        args, kwargs = mock_json_dump.call_args
-
-        assert args[0] == ranking_data.RANKING_DATA_CACHE
-        assert args[1] is mock_file_handle
+        assert args[0] == mock_paths["ranking"]
+        assert args[1] == ranking_data.RANKING_DATA_CACHE
         assert kwargs.get("indent") == 4
         assert kwargs.get("cls") == DataclassJSONEncoder
         assert kwargs.get("ensure_ascii") is False
@@ -336,9 +333,12 @@ def test_save_rankings_success(mock_paths):
 def test_save_rankings_cache_is_none(mock_paths):
     """Test saving when cache hasn't been loaded."""
     ranking_data.RANKING_DATA_CACHE = None
-    with patch("builtins.open") as mock_file_constructor, patch("offkai_bot.data.ranking._log") as mock_log:
+    with (
+        patch("offkai_bot.data.ranking.atomic_write_json") as mock_atomic_write,
+        patch("offkai_bot.data.ranking._log") as mock_log,
+    ):
         ranking_data.save_rankings()
-        mock_file_constructor.assert_not_called()
+        mock_atomic_write.assert_not_called()
         mock_log.error.assert_called_once()
         assert "Attempted to save response data before loading" in mock_log.error.call_args[0][0]
 
@@ -346,9 +346,10 @@ def test_save_rankings_cache_is_none(mock_paths):
 def test_save_rankings_os_error(mock_paths):
     """Test handling OS error during file writing."""
     ranking_data.RANKING_DATA_CACHE = {"User1": RANK_1_OBJ}
-    m_open = mock_open()
-    m_open.side_effect = OSError("Permission denied")
-    with patch("builtins.open", m_open), patch("offkai_bot.data.ranking._log") as mock_log:
+    with (
+        patch("offkai_bot.data.ranking.atomic_write_json", side_effect=OSError("Permission denied")),
+        patch("offkai_bot.data.ranking._log") as mock_log,
+    ):
         ranking_data.save_rankings()
         mock_log.error.assert_called_once()
         assert "Error writing response data" in mock_log.error.call_args[0][0]

--- a/bot/tests/data/test_response.py
+++ b/bot/tests/data/test_response.py
@@ -228,6 +228,7 @@ def test_load_responses_json_decode_error(mock_paths):
         patch("os.path.getsize", return_value=100),
         patch("builtins.open", mock_open(read_data="invalid json")),
         patch("offkai_bot.data.response._log") as mock_log,
+        patch("offkai_bot.data.response.backup_corrupted_file") as mock_backup,
     ):
         responses = response_data._load_responses()
 
@@ -235,6 +236,7 @@ def test_load_responses_json_decode_error(mock_paths):
         assert response_data.RESPONSE_DATA_CACHE == {}
         mock_log.error.assert_called_once()
         assert "Error decoding JSON" in mock_log.error.call_args[0][0]
+        mock_backup.assert_called_once_with(mock_paths["responses"])
 
 
 def test_load_responses_not_a_dict(mock_paths):
@@ -399,32 +401,19 @@ def test_save_responses_success(mock_paths):
         "Event B": make_event_data([RESP_3_OBJ]),
     }
 
-    m_open = mock_open()
-    # Patch both open and json.dump
     with (
-        patch("builtins.open", m_open) as mock_file_constructor,
-        patch("json.dump") as mock_json_dump,
+        patch("offkai_bot.data.response.atomic_write_json") as mock_atomic_write,
         patch("offkai_bot.data.response._log") as mock_log,
     ):
         response_data.save_responses()
 
-        # 1. Check file was opened correctly
-        mock_file_constructor.assert_called_once_with(mock_paths["responses"], "w", encoding="utf-8")
+        # Check atomic_write_json was called correctly
+        mock_atomic_write.assert_called_once()
+        args, kwargs = mock_atomic_write.call_args
 
-        # 2. Get the mock file handle that *should* have been passed to json.dump
-        mock_file_handle = m_open()
+        assert args[0] == mock_paths["responses"]
+        assert args[1] == response_data.RESPONSE_DATA_CACHE
 
-        # 3. Check json.dump was called correctly
-        mock_json_dump.assert_called_once()
-        args, kwargs = mock_json_dump.call_args
-
-        # Check the positional arguments passed to json.dump
-        # args[0] should be the data to dump
-        assert args[0] == response_data.RESPONSE_DATA_CACHE
-        # args[1] should be the file handle
-        assert args[1] is mock_file_handle  # Check it's the handle returned by mock_open
-
-        # Check the keyword arguments passed to json.dump
         assert kwargs.get("indent") == 4
         assert kwargs.get("cls") == DataclassJSONEncoder
         assert kwargs.get("ensure_ascii") is False  # Use 'is False' for explicit boolean check
@@ -436,9 +425,12 @@ def test_save_responses_success(mock_paths):
 def test_save_responses_cache_is_none(mock_paths):
     """Test saving when cache hasn't been loaded."""
     response_data.RESPONSE_DATA_CACHE = None
-    with patch("builtins.open") as mock_file_constructor, patch("offkai_bot.data.response._log") as mock_log:
+    with (
+        patch("offkai_bot.data.response.atomic_write_json") as mock_atomic_write,
+        patch("offkai_bot.data.response._log") as mock_log,
+    ):
         response_data.save_responses()
-        mock_file_constructor.assert_not_called()
+        mock_atomic_write.assert_not_called()
         mock_log.error.assert_called_once()
         assert "Attempted to save response data before loading" in mock_log.error.call_args[0][0]
 
@@ -446,9 +438,10 @@ def test_save_responses_cache_is_none(mock_paths):
 def test_save_responses_os_error(mock_paths):
     """Test handling OS error during file writing."""
     response_data.RESPONSE_DATA_CACHE = {"Event A": make_event_data([RESP_1_OBJ])}
-    m_open = mock_open()
-    m_open.side_effect = OSError("Permission denied")
-    with patch("builtins.open", m_open), patch("offkai_bot.data.response._log") as mock_log:
+    with (
+        patch("offkai_bot.data.response.atomic_write_json", side_effect=OSError("Permission denied")),
+        patch("offkai_bot.data.response._log") as mock_log,
+    ):
         response_data.save_responses()
         mock_log.error.assert_called_once()
         assert "Error writing response data" in mock_log.error.call_args[0][0]


### PR DESCRIPTION
## Summary
- `save_event_data`/`save_responses`/`save_rankings` wrote directly to the target file, so a crash or disk-full mid-write left a truncated file.
- On restart, the loader treated that truncation as a `JSONDecodeError`, reset the cache to empty, and the very next save then overwrote the corrupted-but-recoverable file with `{}`/`[]` for good.
- Added a shared `atomic_write_json()` (temp file in the same directory + `flush()`/`fsync()` + `os.replace()`) used by all three savers, so a crash mid-write can no longer corrupt the on-disk file.
- Added `backup_corrupted_file()`, called from each loader's `JSONDecodeError` handler, which copies the unparseable file aside (`<file>.corrupted-<timestamp>.bak`) before the cache is reset to empty — so the data survives even if a save happens afterward.

Fixes #96

## Test plan
- [x] `uv run pytest bot/tests` — 511 passed
- [x] `uvx ruff check --fix .` — clean
- [x] `uvx ruff format .` — clean
- [x] `uvx ty check` — clean
- [x] New `bot/tests/data/test_atomic.py` covers atomic write success, temp-file cleanup on failure, replacing existing files, and corrupted-file backup behavior (including the missing-file and OSError paths)

🤖 Generated with [Claude Code](https://claude.com/claude-code)