### PR TITLE
Reschedule deadline alerts when an event's deadline changes

### DIFF
--- a/bot/src/offkai_bot/alerts/reminders.py
+++ b/bot/src/offkai_bot/alerts/reminders.py
@@ -47,8 +47,28 @@ def _format_attendee_numbers_jp(response: Response) -> str | None:
     return f"🔢 **受付番号:** {', '.join(parts)}"
 
 
+def unregister_deadline_reminders(event_name: str) -> None:
+    """Removes any pending auto-close, deadline reminder, and role-deletion tasks
+    for the given event."""
+    remove_alerts(
+        lambda task: (
+            isinstance(task, CloseOffkaiTask | SendMessageTask | DeleteRoleTask)
+            and getattr(task, "event_name", None) == event_name
+        )
+    )
+
+
 def register_deadline_reminders(client: discord.Client, event: Event, thread: discord.Thread):
+    """Schedules the auto-close task, deadline reminder pings, and role deletion
+    for an event. Replaces any existing deadline alerts for this event so editing
+    the deadline never leaves stale alerts. No-op for archived events."""
     _log.info("Registering deadline reminders for event '%s'.", event.event_name)
+
+    # Drop any previously scheduled deadline alerts for this event first.
+    unregister_deadline_reminders(event.event_name)
+
+    if event.archived:
+        return
 
     if event.event_deadline and not event.is_past_deadline:
         with contextlib.suppress(AlertTimeInPastError):
@@ -63,6 +83,7 @@ def register_deadline_reminders(client: discord.Client, event: Event, thread: di
                     SendMessageTask(
                         client=client,
                         channel_id=event.channel_id,
+                        event_name=event.event_name,
                         message=f"{role_ping}24 hours until registration deadline for {event.event_name}! "
                         f"See {thread.mention} for details.\n"
                         f"{event.event_name}の登録締切まであと24時間です！"
@@ -76,6 +97,7 @@ def register_deadline_reminders(client: discord.Client, event: Event, thread: di
                     SendMessageTask(
                         client=client,
                         channel_id=event.channel_id,
+                        event_name=event.event_name,
                         message=f"{role_ping}3 days until registration deadline for {event.event_name}! "
                         f"See {thread.mention} for details.\n"
                         f"{event.event_name}の登録締切まであと3日です！"
@@ -89,6 +111,7 @@ def register_deadline_reminders(client: discord.Client, event: Event, thread: di
                     SendMessageTask(
                         client=client,
                         channel_id=event.channel_id,
+                        event_name=event.event_name,
                         message=f"{role_ping}1 week until registration deadline for {event.event_name}! "
                         f"See {thread.mention} for details.\n"
                         f"{event.event_name}の登録締切まであと1週間です！"

--- a/bot/src/offkai_bot/alerts/task.py
+++ b/bot/src/offkai_bot/alerts/task.py
@@ -5,7 +5,8 @@ from dataclasses import dataclass, field
 
 import discord
 
-from offkai_bot.errors import BotCommandError  # Import base error for catching known issues
+from offkai_bot.data.event import get_event
+from offkai_bot.errors import BotCommandError, EventNotFoundError  # Import base error for catching known issues
 from offkai_bot.event_actions import perform_close_event
 
 _log = logging.getLogger(__name__)
@@ -31,6 +32,9 @@ class SendMessageTask(Task):
 
     channel_id: int
     message: str
+    # Optional tag linking this message to an event, so pending reminders can be
+    # unregistered when the event's deadline changes or the event is archived.
+    event_name: str | None = None
 
     async def action(self):
         """Sends the defined message to the specified channel."""
@@ -75,6 +79,25 @@ class CloseOffkaiTask(Task):
         Handles errors specific to the closing process. Overrides base action.
         """
         _log.info("Executing CloseOffkaiTask for event: '%s'", self.event_name)
+
+        # Reload the event at fire time; the deadline may have changed since this
+        # task was scheduled. Skip if the event is gone, archived, or the deadline
+        # has been moved into the future (a rescheduled task will handle it).
+        try:
+            event = get_event(self.event_name)
+        except EventNotFoundError:
+            _log.warning("CloseOffkaiTask: event '%s' no longer exists. Skipping.", self.event_name)
+            return
+        if event.archived:
+            _log.info("CloseOffkaiTask: event '%s' is archived. Skipping.", self.event_name)
+            return
+        if event.event_deadline and not event.is_past_deadline:
+            _log.info(
+                "CloseOffkaiTask: deadline for event '%s' has moved into the future. Skipping.",
+                self.event_name,
+            )
+            return
+
         try:
             # Call the core closing logic function
             # self.client is inherited from the Task dataclass

--- a/bot/src/offkai_bot/cogs/events.py
+++ b/bot/src/offkai_bot/cogs/events.py
@@ -11,6 +11,7 @@ from offkai_bot.alerts.reminders import (
     register_checkin_reminder,
     register_deadline_reminders,
     unregister_checkin_reminder,
+    unregister_deadline_reminders,
 )
 from offkai_bot.data.event import (
     add_event,
@@ -298,6 +299,12 @@ class EventsCog(commands.Cog):
 
         try:
             thread = await fetch_thread_for_event(self.bot, modified_event)
+
+            # Re-schedule the auto-close and deadline reminder alerts in case the
+            # deadline changed. register_deadline_reminders drops the old alerts
+            # first, so this never leaves alerts keyed to the old deadline.
+            register_deadline_reminders(self.bot, modified_event, thread)
+
             try:
                 await thread.send(f"**Event Updated:**\n{update_msg}")
             except discord.HTTPException as e:
@@ -381,6 +388,7 @@ class EventsCog(commands.Cog):
         archived_event = archive_event(event_name)
         save_event_data()
         unregister_checkin_reminder(archived_event.event_name)
+        unregister_deadline_reminders(archived_event.event_name)
         await update_event_message(self.bot, archived_event)
 
         try:

--- a/bot/tests/alerts/test_register_alerts.py
+++ b/bot/tests/alerts/test_register_alerts.py
@@ -1,11 +1,12 @@
 # tests/alerts/test_alerts.py
 
+import copy
 from datetime import UTC, datetime, timedelta
 from unittest.mock import ANY, AsyncMock, MagicMock, patch
 
 import discord
 import pytest
-from offkai_bot.alerts.reminders import register_deadline_reminders
+from offkai_bot.alerts.reminders import register_deadline_reminders, unregister_deadline_reminders
 from offkai_bot.alerts.task import (  # Import base Task for type hinting
     CloseOffkaiTask,
     DeleteRoleTask,
@@ -254,6 +255,7 @@ def test_register_deadline_reminders_success(mock_log, mock_register_alert, mock
             client=mock_client,
             channel_id=event.channel_id,
             message=ANY,
+            event_name=event.event_name,
         ),
     )
     mock_log.info.assert_any_call("Registered 24 hour reminder for '%s'.", event.event_name)
@@ -265,6 +267,7 @@ def test_register_deadline_reminders_success(mock_log, mock_register_alert, mock
             client=mock_client,
             channel_id=event.channel_id,
             message=ANY,
+            event_name=event.event_name,
         ),
     )
     mock_log.info.assert_any_call("Registered 3 day reminder for '%s'.", event.event_name)
@@ -276,6 +279,7 @@ def test_register_deadline_reminders_success(mock_log, mock_register_alert, mock
             client=mock_client,
             channel_id=event.channel_id,
             message=ANY,
+            event_name=event.event_name,
         ),
     )
     mock_log.info.assert_any_call("Registered 1 week reminder for '%s'.", event.event_name)
@@ -427,6 +431,7 @@ def test_register_deadline_reminders_past_reminders_suppressed(
             client=mock_client,
             channel_id=event.channel_id,
             message=ANY,
+            event_name=event.event_name,
         ),
     )
     mock_log.info.assert_any_call("Registered 24 hour reminder for '%s'.", event.event_name)
@@ -496,3 +501,65 @@ def test_register_role_deletion_independent_of_deadline(
         expected_delete_time,
         DeleteRoleTask(client=mock_client, event_name=event.event_name, role_id=55555),
     )
+
+
+# --- Tests for unregister_deadline_reminders / re-registration ---
+# These use the real register_alert so alerts land in the (cleared) global registry.
+
+
+def _all_scheduled_tasks() -> list[Task]:
+    return [task for tasks in alerts._scheduled_tasks.values() for task in tasks]
+
+
+def test_unregister_deadline_reminders_removes_only_matching_event(mock_client, mock_thread, future_event):
+    """Test that unregistering removes all of one event's alerts but leaves other events' alerts."""
+    # Arrange
+    other_event = copy.deepcopy(future_event)
+    other_event.event_name = "Other Event"
+    future_event.role_id = 55555
+
+    register_deadline_reminders(mock_client, future_event, mock_thread)
+    register_deadline_reminders(mock_client, other_event, mock_thread)
+    # 5 tasks for future_event (close + 3 reminders + role deletion) + 4 for other_event
+    assert len(_all_scheduled_tasks()) == 9
+
+    # Act
+    unregister_deadline_reminders(future_event.event_name)
+
+    # Assert
+    remaining = _all_scheduled_tasks()
+    assert len(remaining) == 4
+    assert all(task.event_name == other_event.event_name for task in remaining)
+
+
+def test_register_deadline_reminders_replaces_existing_alerts(mock_client, mock_thread, future_event):
+    """Test that re-registering after a deadline change leaves no alerts at the old deadline."""
+    # Arrange
+    register_deadline_reminders(mock_client, future_event, mock_thread)
+    old_close_key = future_event.event_deadline.astimezone(JST).strftime(alerts._TIME_KEY_FORMAT)
+    assert old_close_key in alerts._scheduled_tasks
+
+    # Act - extend the deadline and re-register
+    future_event.event_deadline = future_event.event_deadline + timedelta(days=2, hours=1)
+    future_event.event_datetime = future_event.event_deadline + timedelta(days=5)
+    register_deadline_reminders(mock_client, future_event, mock_thread)
+
+    # Assert - no alerts remain at the old deadline; close task is at the new deadline
+    new_close_key = future_event.event_deadline.astimezone(JST).strftime(alerts._TIME_KEY_FORMAT)
+    assert old_close_key not in alerts._scheduled_tasks
+    assert any(isinstance(task, CloseOffkaiTask) for task in alerts._scheduled_tasks[new_close_key])
+    assert len(_all_scheduled_tasks()) == 4
+
+
+def test_register_deadline_reminders_archived_event_clears_alerts(mock_client, mock_thread, future_event):
+    """Test that registering an archived event removes existing alerts and adds none."""
+    # Arrange
+    register_deadline_reminders(mock_client, future_event, mock_thread)
+    assert _all_scheduled_tasks()
+
+    # Act
+    future_event.archived = True
+    register_deadline_reminders(mock_client, future_event, mock_thread)
+
+    # Assert
+    assert not _all_scheduled_tasks()

--- a/bot/tests/commands/test_archive_offkai.py
+++ b/bot/tests/commands/test_archive_offkai.py
@@ -1,12 +1,15 @@
 # tests/commands/test_archive_offkai.py
 
 import logging
+from datetime import UTC, datetime, timedelta
 from unittest.mock import ANY, AsyncMock, MagicMock, patch
 
 import discord
 import pytest
 from discord import app_commands
 from discord.ext import commands
+from offkai_bot.alerts.alerts import register_alert
+from offkai_bot.alerts.task import CloseOffkaiTask, SendMessageTask
 
 # Import the function to test and relevant errors/classes
 from offkai_bot.cogs.events import EventsCog
@@ -18,6 +21,8 @@ from offkai_bot.errors import (
     ThreadAccessError,
     ThreadNotFoundError,
 )
+
+from offkai_bot.alerts import alerts
 
 # pytest marker for async tests
 pytestmark = pytest.mark.asyncio
@@ -129,6 +134,50 @@ async def test_archive_offkai_success(
     )
     mock_log.info.assert_called()
     mock_log.warning.assert_not_called()
+
+
+@patch("offkai_bot.cogs.events.fetch_thread_for_event", new_callable=AsyncMock)
+@patch("offkai_bot.cogs.events.update_event_message", new_callable=AsyncMock)
+@patch("offkai_bot.cogs.events.save_event_data")
+@patch("offkai_bot.cogs.events.archive_event")
+@patch("offkai_bot.cogs.events._log")
+async def test_archive_offkai_unregisters_deadline_alerts(
+    mock_log,
+    mock_archive_event_func,
+    mock_save_data,
+    mock_update_msg_view,
+    mock_fetch_thread,
+    mock_interaction,
+    mock_thread,
+    mock_archived_event_obj,
+    prepopulated_event_cache,
+    mock_cog,
+):
+    """Test that archiving removes any pending auto-close and reminder alerts for the event."""
+    # Arrange
+    event_name_to_archive = "Summer Bash"
+    mock_archive_event_func.return_value = mock_archived_event_obj
+    mock_fetch_thread.return_value = mock_thread
+    mock_thread.archived = False
+
+    # Simulate alerts scheduled at event creation.
+    future_time = datetime.now(UTC) + timedelta(days=5)
+    register_alert(future_time, CloseOffkaiTask(client=mock_cog.bot, event_name=event_name_to_archive))
+    register_alert(
+        future_time - timedelta(days=1),
+        SendMessageTask(client=mock_cog.bot, channel_id=1001, message="reminder", event_name=event_name_to_archive),
+    )
+
+    # Act
+    await EventsCog.archive_offkai.callback(
+        mock_cog,
+        mock_interaction,
+        event_name=event_name_to_archive,
+    )
+
+    # Assert - no alerts for the archived event remain scheduled
+    remaining = [task for tasks in alerts._scheduled_tasks.values() for task in tasks]
+    assert not any(getattr(task, "event_name", None) == event_name_to_archive for task in remaining)
 
 
 @pytest.mark.parametrize(

--- a/bot/tests/commands/test_modify_offkai.py
+++ b/bot/tests/commands/test_modify_offkai.py
@@ -9,6 +9,8 @@ import discord
 import pytest
 from discord import app_commands
 from discord.ext import commands
+from offkai_bot.alerts.alerts import register_alert
+from offkai_bot.alerts.task import CloseOffkaiTask
 
 # Import the function to test and relevant errors/classes
 from offkai_bot.cogs.events import EventsCog
@@ -28,6 +30,8 @@ from offkai_bot.errors import (
     ThreadNotFoundError,
 )
 from offkai_bot.util import JST
+
+from offkai_bot.alerts import alerts
 
 # pytest marker for async tests
 pytestmark = pytest.mark.asyncio
@@ -169,6 +173,55 @@ async def test_modify_offkai_success(
     )
     mock_log.warning.assert_not_called()
     mock_log.error.assert_not_called()
+
+
+@patch("offkai_bot.cogs.events.fetch_thread_for_event", new_callable=AsyncMock)
+@patch("offkai_bot.cogs.events.update_event_message", new_callable=AsyncMock)
+@patch("offkai_bot.cogs.events.save_event_data")
+@patch("offkai_bot.cogs.events.update_event_details")
+@patch("offkai_bot.cogs.events._log")
+async def test_modify_offkai_reschedules_deadline_alerts(
+    mock_log,
+    mock_update_details,
+    mock_save_data,
+    mock_update_msg_view,
+    mock_fetch_thread,
+    mock_interaction,
+    mock_thread,
+    mock_modified_event,
+    prepopulated_event_cache,
+    mock_cog,
+):
+    """Test that modifying an event replaces the auto-close alert keyed to the old deadline."""
+    # Arrange
+    event_name_to_modify = "Summer Bash"
+
+    # Simulate the auto-close alert registered at event creation for the old deadline.
+    old_deadline = datetime.now(UTC) + timedelta(days=3)
+    register_alert(old_deadline, CloseOffkaiTask(client=mock_cog.bot, event_name=event_name_to_modify))
+    old_key = old_deadline.astimezone(JST).strftime(alerts._TIME_KEY_FORMAT)
+    assert old_key in alerts._scheduled_tasks
+
+    mock_update_details.return_value = mock_modified_event
+    mock_fetch_thread.return_value = mock_thread
+    mock_thread.id = mock_modified_event.thread_id
+    mock_thread.mention = f"<#{mock_thread.id}>"
+
+    # Act
+    await EventsCog.modify_offkai.callback(
+        mock_cog,
+        mock_interaction,
+        event_name=event_name_to_modify,
+        update_msg="Deadline extended!",
+        deadline="2030-01-01 18:00",  # Parsing happens inside the mocked update_event_details
+    )
+
+    # Assert - the alert keyed to the old deadline is gone...
+    assert old_key not in alerts._scheduled_tasks
+    # ...and a new auto-close alert is scheduled at the new deadline.
+    new_key = mock_modified_event.event_deadline.astimezone(JST).strftime(alerts._TIME_KEY_FORMAT)
+    close_tasks = [t for t in alerts._scheduled_tasks.get(new_key, []) if isinstance(t, CloseOffkaiTask)]
+    assert len(close_tasks) == 1
 
 
 @patch("offkai_bot.cogs.events.fetch_thread_for_event", new_callable=AsyncMock)

--- a/bot/tests/conftest.py
+++ b/bot/tests/conftest.py
@@ -4,6 +4,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import discord
 import pytest
+from offkai_bot.alerts.alerts import clear_alerts
 from offkai_bot.data.event import Event
 
 from offkai_bot.data import event as event_data
@@ -34,11 +35,13 @@ def clear_caches():
     event_data.EVENT_DATA_CACHE = None
     response_data.RESPONSE_DATA_CACHE = None
     ranking_data.RANKING_DATA_CACHE = None
+    clear_alerts()
     yield  # Test runs here
     # After test
     event_data.EVENT_DATA_CACHE = None
     response_data.RESPONSE_DATA_CACHE = None
     ranking_data.RANKING_DATA_CACHE = None
+    clear_alerts()
 
 
 @pytest.fixture

--- a/bot/tests/test_task.py
+++ b/bot/tests/test_task.py
@@ -186,12 +186,14 @@ async def test_send_message_task_send_unexpected_error(mock_log, mock_client, mo
 
 # Patch the perform_close_event function *where it's looked up* by task.py
 @patch("offkai_bot.alerts.task.perform_close_event", new_callable=AsyncMock)
+@patch("offkai_bot.alerts.task.get_event")
 @patch("offkai_bot.alerts.task._log")
-async def test_close_offkai_task_success(mock_log, mock_perform_close, mock_client):
+async def test_close_offkai_task_success(mock_log, mock_get_event, mock_perform_close, mock_client):
     """Test CloseOffkaiTask successfully calls perform_close_event."""
     # Arrange
     event_name = "Event To Close"
     task = CloseOffkaiTask(client=mock_client, event_name=event_name)
+    mock_get_event.return_value = MagicMock(archived=False, is_past_deadline=True)
     # Default close_msg is used
 
     # Act
@@ -211,12 +213,14 @@ async def test_close_offkai_task_success(mock_log, mock_perform_close, mock_clie
 
 
 @patch("offkai_bot.alerts.task.perform_close_event", new_callable=AsyncMock)
+@patch("offkai_bot.alerts.task.get_event")
 @patch("offkai_bot.alerts.task._log")
-async def test_close_offkai_task_handles_bot_command_error(mock_log, mock_perform_close, mock_client):
+async def test_close_offkai_task_handles_bot_command_error(mock_log, mock_get_event, mock_perform_close, mock_client):
     """Test CloseOffkaiTask handles BotCommandError from perform_close_event."""
     # Arrange
     event_name = "Missing Event"
     task = CloseOffkaiTask(client=mock_client, event_name=event_name)
+    mock_get_event.return_value = MagicMock(archived=False, is_past_deadline=True)
     # Simulate EventNotFoundError (which inherits from BotCommandError)
     error_to_raise = EventNotFoundError(event_name)
     # Assign a specific log level to the error instance for testing
@@ -241,12 +245,14 @@ async def test_close_offkai_task_handles_bot_command_error(mock_log, mock_perfor
 
 
 @patch("offkai_bot.alerts.task.perform_close_event", new_callable=AsyncMock)
+@patch("offkai_bot.alerts.task.get_event")
 @patch("offkai_bot.alerts.task._log")
-async def test_close_offkai_task_handles_http_exception(mock_log, mock_perform_close, mock_client):
+async def test_close_offkai_task_handles_http_exception(mock_log, mock_get_event, mock_perform_close, mock_client):
     """Test CloseOffkaiTask handles discord.HTTPException from perform_close_event."""
     # Arrange
     event_name = "Event With API Error"
     task = CloseOffkaiTask(client=mock_client, event_name=event_name)
+    mock_get_event.return_value = MagicMock(archived=False, is_past_deadline=True)
     error_to_raise = discord.HTTPException(MagicMock(), "Discord API failed")
     mock_perform_close.side_effect = error_to_raise
 
@@ -264,12 +270,16 @@ async def test_close_offkai_task_handles_http_exception(mock_log, mock_perform_c
 
 
 @patch("offkai_bot.alerts.task.perform_close_event", new_callable=AsyncMock)
+@patch("offkai_bot.alerts.task.get_event")
 @patch("offkai_bot.alerts.task._log")
-async def test_close_offkai_task_handles_unexpected_exception(mock_log, mock_perform_close, mock_client):
+async def test_close_offkai_task_handles_unexpected_exception(
+    mock_log, mock_get_event, mock_perform_close, mock_client
+):
     """Test CloseOffkaiTask handles generic Exception from perform_close_event."""
     # Arrange
     event_name = "Event With Unexpected Error"
     task = CloseOffkaiTask(client=mock_client, event_name=event_name)
+    mock_get_event.return_value = MagicMock(archived=False, is_past_deadline=True)
     error_to_raise = ValueError("Something completely unexpected happened")
     mock_perform_close.side_effect = error_to_raise
 
@@ -284,6 +294,65 @@ async def test_close_offkai_task_handles_unexpected_exception(mock_log, mock_per
     )
     mock_log.log.assert_not_called()
     mock_log.error.assert_not_called()
+
+
+@patch("offkai_bot.alerts.task.perform_close_event", new_callable=AsyncMock)
+@patch("offkai_bot.alerts.task.get_event")
+@patch("offkai_bot.alerts.task._log")
+async def test_close_offkai_task_skips_when_event_not_found(mock_log, mock_get_event, mock_perform_close, mock_client):
+    """Test CloseOffkaiTask skips closing when the event no longer exists."""
+    # Arrange
+    event_name = "Deleted Event"
+    task = CloseOffkaiTask(client=mock_client, event_name=event_name)
+    mock_get_event.side_effect = EventNotFoundError(event_name)
+
+    # Act
+    await task.action()
+
+    # Assert
+    mock_perform_close.assert_not_awaited()
+    mock_log.warning.assert_called_once_with("CloseOffkaiTask: event '%s' no longer exists. Skipping.", event_name)
+
+
+@patch("offkai_bot.alerts.task.perform_close_event", new_callable=AsyncMock)
+@patch("offkai_bot.alerts.task.get_event")
+@patch("offkai_bot.alerts.task._log")
+async def test_close_offkai_task_skips_when_event_archived(mock_log, mock_get_event, mock_perform_close, mock_client):
+    """Test CloseOffkaiTask skips closing when the event has been archived."""
+    # Arrange
+    event_name = "Archived Event"
+    task = CloseOffkaiTask(client=mock_client, event_name=event_name)
+    mock_get_event.return_value = MagicMock(archived=True)
+
+    # Act
+    await task.action()
+
+    # Assert
+    mock_perform_close.assert_not_awaited()
+    mock_log.info.assert_any_call("CloseOffkaiTask: event '%s' is archived. Skipping.", event_name)
+
+
+@patch("offkai_bot.alerts.task.perform_close_event", new_callable=AsyncMock)
+@patch("offkai_bot.alerts.task.get_event")
+@patch("offkai_bot.alerts.task._log")
+async def test_close_offkai_task_skips_when_deadline_moved_to_future(
+    mock_log, mock_get_event, mock_perform_close, mock_client
+):
+    """Test CloseOffkaiTask skips closing when the deadline was moved into the future."""
+    # Arrange
+    event_name = "Extended Event"
+    task = CloseOffkaiTask(client=mock_client, event_name=event_name)
+    mock_get_event.return_value = MagicMock(archived=False, is_past_deadline=False)
+
+    # Act
+    await task.action()
+
+    # Assert
+    mock_perform_close.assert_not_awaited()
+    mock_log.info.assert_any_call(
+        "CloseOffkaiTask: deadline for event '%s' has moved into the future. Skipping.",
+        event_name,
+    )
 
 
 # --- Tests for DeleteRoleTask ---


### PR DESCRIPTION
Fixes #97.

## Problem

`/modify_offkai` only re-registered the check-in reminder. The `CloseOffkaiTask` and the 1-week/3-day/24-hour `SendMessageTask` reminders registered at event creation stayed keyed to the **old** deadline:

- Extending a deadline still auto-closed responses at the *original* deadline (`CloseOffkaiTask.action()` closed unconditionally).
- The old reminder pings fired on the old schedule, and none were registered for the new deadline.
- `/archive_offkai` only unregistered the check-in reminder, so a pending auto-close and the `@role` reminder pings for an archived event still fired.

## Fix

- **`alerts/reminders.py`**: added `unregister_deadline_reminders(event_name)` (built on the existing `remove_alerts` predicate helper) and made `register_deadline_reminders()` self-replacing — it drops the event's old auto-close/reminder/role-deletion alerts first and is a no-op for archived events, mirroring `register_checkin_reminder()`.
- **`alerts/task.py`**: `SendMessageTask` gained an optional `event_name` tag so an event's reminder pings can be found and removed. Defense in depth: `CloseOffkaiTask.action()` now reloads the event at fire time and skips if the event is gone, archived, or the deadline has moved into the future (same pattern as `SendCheckinReminderTask.action()`).
- **`cogs/events.py`**: `/modify_offkai` re-registers the deadline alerts after fetching the event thread; `/archive_offkai` unregisters them alongside the check-in reminder.

## Tests

- New tests for the fire-time skip behaviors of `CloseOffkaiTask` (event not found / archived / deadline extended).
- New tests for `unregister_deadline_reminders` scoping, re-registration replacing alerts at the old deadline, and archived events clearing alerts.
- Command-level tests: `/modify_offkai` replaces the auto-close alert keyed to the old deadline; `/archive_offkai` removes all pending alerts for the event.
- `conftest.py` now clears the global alert registry between tests.

All 511 bot tests pass; ruff, ty, and the frontend lint/build gates are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)