### PR TITLE
Defer slash command interactions before slow pre-response work

### DIFF
--- a/bot/src/offkai_bot/cogs/events.py
+++ b/bot/src/offkai_bot/cogs/events.py
@@ -192,6 +192,11 @@ class EventsCog(commands.Cog):
         validate_event_datetime(event_datetime)
         validate_event_deadline(event_datetime, event_deadline)
 
+        # 4. Acknowledge the interaction before the slow Discord API calls below
+        # (thread/role creation, event message send) exceed the 3-second window.
+        # The confirmation is a public announcement, so defer non-ephemerally.
+        await interaction.response.defer()
+
         # --- Discord Interaction Block ---
         try:
             assert isinstance(interaction.channel, discord.TextChannel)
@@ -249,9 +254,8 @@ class EventsCog(commands.Cog):
         if announce_msg:
             announce_text += f"{announce_msg}\n\n"
         announce_text += f"Join the discussion and RSVP here: {thread.mention}"
-        await interaction.response.send_message(announce_text)
+        message = await interaction.followup.send(announce_text, wait=True)
 
-        message = await interaction.original_response()
         try:
             await message.pin()
         except discord.Forbidden as e:
@@ -292,6 +296,10 @@ class EventsCog(commands.Cog):
         max_capacity: int | None = None,
     ):
         validate_interaction_context(interaction)
+
+        # Acknowledge early: a capacity increase can promote waitlisted users,
+        # which fetches and DMs each of them — easily exceeding the 3-second window.
+        await interaction.response.defer()
 
         old_event = get_event(event_name)
         old_capacity = old_event.max_capacity
@@ -351,7 +359,7 @@ class EventsCog(commands.Cog):
         except Exception as e:
             _log.exception("Unexpected error sending update message for event '%s': %s", event_name, e)
 
-        await interaction.response.send_message(
+        await interaction.followup.send(
             f"✅ Event '{event_name}' modified successfully. Announcement posted in thread (if possible)."
         )
 
@@ -366,9 +374,10 @@ class EventsCog(commands.Cog):
     @app_commands.checks.has_role("Offkai Organizer")
     @log_command_usage
     async def close_offkai(self, interaction: discord.Interaction, event_name: str, close_msg: str | None = None):
+        await interaction.response.defer()
         try:
             await perform_close_event(self.bot, event_name, close_msg)
-            await interaction.response.send_message(f"✅ Responses for '{event_name}' have been closed.")
+            await interaction.followup.send(f"✅ Responses for '{event_name}' have been closed.")
         except Exception as e:
             _log.error("Error during /close_offkai command for '%s': %s", event_name, e, exc_info=e)
             raise e
@@ -384,6 +393,7 @@ class EventsCog(commands.Cog):
     @app_commands.checks.has_role("Offkai Organizer")
     @log_command_usage
     async def reopen_offkai(self, interaction: discord.Interaction, event_name: str, reopen_msg: str | None = None):
+        await interaction.response.defer()
         reopened_event = set_event_open_status(event_name, target_open_status=True)
         clear_attendee_numbers(event_name)
         save_responses()
@@ -408,7 +418,7 @@ class EventsCog(commands.Cog):
             except Exception as e:
                 _log.exception("Unexpected error sending reopening message for event '%s': %s", event_name, e)
 
-        await interaction.response.send_message(f"✅ Responses for '{event_name}' have been reopened.")
+        await interaction.followup.send(f"✅ Responses for '{event_name}' have been reopened.")
 
     @app_commands.command(
         name="archive_offkai",
@@ -420,6 +430,7 @@ class EventsCog(commands.Cog):
     @app_commands.checks.has_role("Offkai Organizer")
     @log_command_usage
     async def archive_offkai(self, interaction: discord.Interaction, event_name: str):
+        await interaction.response.defer()
         archived_event = archive_event(event_name)
         save_event_data()
         unregister_checkin_reminder(archived_event.event_name)
@@ -451,7 +462,7 @@ class EventsCog(commands.Cog):
                 except (discord.Forbidden, discord.HTTPException) as e:
                     _log.warning("Failed to delete participant role for '%s': %s", event_name, e)
 
-        await interaction.response.send_message(f"✅ Event '{event_name}' has been archived.")
+        await interaction.followup.send(f"✅ Event '{event_name}' has been archived.")
 
     @app_commands.command(
         name="broadcast",
@@ -461,12 +472,13 @@ class EventsCog(commands.Cog):
     @app_commands.checks.has_role("Offkai Organizer")
     @log_command_usage
     async def broadcast(self, interaction: discord.Interaction, event_name: str, message: str):
+        await interaction.response.defer(ephemeral=True)
         event = get_event(event_name)
         thread = await fetch_thread_for_event(self.bot, event)
 
         try:
             await thread.send(f"{message}")
-            await interaction.response.send_message(f"📣 Sent broadcast to channel {thread.mention}.", ephemeral=True)
+            await interaction.followup.send(f"📣 Sent broadcast to channel {thread.mention}.", ephemeral=True)
         except discord.Forbidden as e:
             raise BroadcastPermissionError(thread, e)
         except discord.HTTPException as e:
@@ -480,13 +492,14 @@ class EventsCog(commands.Cog):
     @app_commands.checks.has_role("Offkai Organizer")
     @log_command_usage
     async def delete_response(self, interaction: discord.Interaction, event_name: str, member: discord.Member):
+        await interaction.response.defer(ephemeral=True)
         event = get_event(event_name)
         remove_response(event_name, member.id)
 
         if event.role_id and interaction.guild:
             await remove_event_role(interaction.guild, member.id, event.role_id)
 
-        await interaction.response.send_message(
+        await interaction.followup.send(
             f"🚮 Deleted response from user {member.mention} for '{event_name}'.",
             ephemeral=True,
         )
@@ -515,12 +528,13 @@ class EventsCog(commands.Cog):
     @app_commands.checks.has_role("Offkai Organizer")
     @log_command_usage
     async def promote(self, interaction: discord.Interaction, event_name: str, username: str):
+        await interaction.response.defer(ephemeral=True)
         event = get_event(event_name)
 
         try:
             user_id = int(username)
         except ValueError:
-            await interaction.response.send_message(
+            await interaction.followup.send(
                 "Invalid user selection. Please use the autocomplete dropdown.", ephemeral=True
             )
             return
@@ -544,7 +558,7 @@ class EventsCog(commands.Cog):
         if event.role_id and interaction.guild:
             await assign_event_role(interaction.guild, user_id, event.role_id)
 
-        await interaction.response.send_message(
+        await interaction.followup.send(
             f"Promoted user <@{user_id}> from the waitlist for '{event_name}'.",
             ephemeral=True,
         )
@@ -589,6 +603,7 @@ class EventsCog(commands.Cog):
         nicknames: bool = False,
         drinks: bool = False,
     ):
+        await interaction.response.defer(ephemeral=True)
         get_event(event_name)
         total_count, attendee_list = calculate_attendance(event_name, nicknames=nicknames, drinks=drinks, sort=sort)
 
@@ -600,7 +615,7 @@ class EventsCog(commands.Cog):
                     f"Attendance for **{event_name}** is attached as a text file.",
                     file=_attendance_file(event_name, output),
                 )
-                await interaction.response.send_message(
+                await interaction.followup.send(
                     f"Attendance list for '{event_name}' has been sent to you by DM.",
                     ephemeral=True,
                 )
@@ -611,14 +626,14 @@ class EventsCog(commands.Cog):
                     event_name,
                     e,
                 )
-                await interaction.response.send_message(
+                await interaction.followup.send(
                     "I couldn't send you a DM, so I've attached the attendance list here.",
                     file=_attendance_file(event_name, output),
                     ephemeral=True,
                 )
             return
 
-        await interaction.response.send_message(output, ephemeral=True)
+        await interaction.followup.send(output, ephemeral=True)
 
     @app_commands.command(
         name="attendance_report",
@@ -628,9 +643,10 @@ class EventsCog(commands.Cog):
     @app_commands.checks.has_role("Offkai Organizer")
     @log_command_usage
     async def attendance_report(self, interaction: discord.Interaction, event_name: str):
+        await interaction.response.defer(ephemeral=True)
         event = get_event(event_name)
         if event.open or not has_complete_attendee_numbers(event_name):
-            await interaction.response.send_message(
+            await interaction.followup.send(
                 "Attendee numbers are generated when an event is closed. Close the event before exporting this report.",
                 ephemeral=True,
             )
@@ -642,7 +658,7 @@ class EventsCog(commands.Cog):
                 f"Attendance report for **{event_name}** is attached as a CSV file.",
                 file=_attendance_report_file(event_name, report_rows),
             )
-            await interaction.response.send_message(
+            await interaction.followup.send(
                 f"Attendance report for '{event_name}' has been sent to you by DM.",
                 ephemeral=True,
             )
@@ -653,7 +669,7 @@ class EventsCog(commands.Cog):
                 event_name,
                 e,
             )
-            await interaction.response.send_message(
+            await interaction.followup.send(
                 "I couldn't send you a DM, so I've attached the attendance report here.",
                 file=_attendance_report_file(event_name, report_rows),
                 ephemeral=True,

--- a/bot/tests/commands/test_archive_offkai.py
+++ b/bot/tests/commands/test_archive_offkai.py
@@ -54,7 +54,8 @@ def mock_interaction():
     # Mock response methods
     interaction.response = MagicMock()
     interaction.response.send_message = AsyncMock()
-    interaction.followup = MagicMock(send=AsyncMock())  # In case response is done
+    interaction.response.defer = AsyncMock()
+    interaction.followup = MagicMock(send=AsyncMock())
 
     return interaction
 
@@ -124,9 +125,7 @@ async def test_archive_offkai_success(
     # Check archiving the Discord thread
     mock_thread.edit.assert_awaited_once_with(archived=True, locked=True)
     # Check final interaction response
-    mock_interaction.response.send_message.assert_awaited_once_with(
-        f"✅ Event '{event_name_to_archive}' has been archived."
-    )
+    mock_interaction.followup.send.assert_awaited_once_with(f"✅ Event '{event_name_to_archive}' has been archived.")
     mock_log.info.assert_called()
     mock_log.warning.assert_not_called()
 
@@ -174,7 +173,7 @@ async def test_archive_offkai_data_layer_errors(
     mock_save_data.assert_not_called()
     mock_update_msg_view.assert_not_awaited()
     mock_fetch_thread.assert_not_awaited()  # Check helper wasn't called
-    mock_interaction.response.send_message.assert_not_awaited()
+    mock_interaction.followup.send.assert_not_awaited()
 
 
 # --- UPDATED TEST ---
@@ -223,9 +222,7 @@ async def test_archive_offkai_fetch_thread_not_found_error(  # Renamed test
     assert log_call_args[2] == event_name_to_archive
 
     # Final confirmation should still be sent
-    mock_interaction.response.send_message.assert_awaited_once_with(
-        f"✅ Event '{event_name_to_archive}' has been archived."
-    )
+    mock_interaction.followup.send.assert_awaited_once_with(f"✅ Event '{event_name_to_archive}' has been archived.")
 
 
 # --- END UPDATED TEST ---
@@ -274,9 +271,7 @@ async def test_archive_offkai_fetch_thread_missing_id_error(
     assert log_call_args[1] == "Could not archive thread for event '%s': %s"
     assert log_call_args[2] == event_name_to_archive
 
-    mock_interaction.response.send_message.assert_awaited_once_with(
-        f"✅ Event '{event_name_to_archive}' has been archived."
-    )
+    mock_interaction.followup.send.assert_awaited_once_with(f"✅ Event '{event_name_to_archive}' has been archived.")
 
 
 # --- END NEW TEST ---
@@ -325,9 +320,7 @@ async def test_archive_offkai_fetch_thread_access_error(
     assert log_call_args[1] == "Could not archive thread for event '%s': %s"
     assert log_call_args[2] == event_name_to_archive
 
-    mock_interaction.response.send_message.assert_awaited_once_with(
-        f"✅ Event '{event_name_to_archive}' has been archived."
-    )
+    mock_interaction.followup.send.assert_awaited_once_with(f"✅ Event '{event_name_to_archive}' has been archived.")
 
 
 # --- END NEW TEST ---
@@ -379,9 +372,7 @@ async def test_archive_offkai_thread_already_archived(
     mock_log.warning.assert_not_called()  # No warning needed if already archived
 
     # Final confirmation should still be sent
-    mock_interaction.response.send_message.assert_awaited_once_with(
-        f"✅ Event '{event_name_to_archive}' has been archived."
-    )
+    mock_interaction.followup.send.assert_awaited_once_with(f"✅ Event '{event_name_to_archive}' has been archived.")
 
 
 # --- UPDATED PATCHES ---
@@ -436,9 +427,7 @@ async def test_archive_offkai_thread_edit_fails(
     assert mock_log.warning.call_args[0][1] == mock_thread.id
 
     # Final confirmation should still be sent
-    mock_interaction.response.send_message.assert_awaited_once_with(
-        f"✅ Event '{event_name_to_archive}' has been archived."
-    )
+    mock_interaction.followup.send.assert_awaited_once_with(f"✅ Event '{event_name_to_archive}' has been archived.")
 
 
 @patch("offkai_bot.cogs.events.fetch_thread_for_event", new_callable=AsyncMock)
@@ -482,9 +471,7 @@ async def test_archive_offkai_deletes_role(
     mock_interaction.guild.get_role.assert_called_once_with(99999)
     mock_role.delete.assert_awaited_once_with(reason=f"Offkai '{event_name_to_archive}' archived")
     mock_log.info.assert_any_call("Deleted participant role %s for archived event '%s'.", 99999, event_name_to_archive)
-    mock_interaction.response.send_message.assert_awaited_once_with(
-        f"✅ Event '{event_name_to_archive}' has been archived."
-    )
+    mock_interaction.followup.send.assert_awaited_once_with(f"✅ Event '{event_name_to_archive}' has been archived.")
 
 
 @patch("offkai_bot.cogs.events.fetch_thread_for_event", new_callable=AsyncMock)
@@ -531,6 +518,4 @@ async def test_archive_offkai_role_deletion_failure_non_fatal(
     assert warning_call[0] == "Failed to delete participant role for '%s': %s"
     assert warning_call[1] == event_name_to_archive
     # Archive still succeeds
-    mock_interaction.response.send_message.assert_awaited_once_with(
-        f"✅ Event '{event_name_to_archive}' has been archived."
-    )
+    mock_interaction.followup.send.assert_awaited_once_with(f"✅ Event '{event_name_to_archive}' has been archived.")

--- a/bot/tests/commands/test_attendance.py
+++ b/bot/tests/commands/test_attendance.py
@@ -50,7 +50,8 @@ def mock_interaction():
     # Mock response methods
     interaction.response = MagicMock()
     interaction.response.send_message = AsyncMock()
-    interaction.followup = MagicMock(send=AsyncMock())  # In case response is done
+    interaction.response.defer = AsyncMock()
+    interaction.followup = MagicMock(send=AsyncMock())
 
     return interaction
 
@@ -141,7 +142,7 @@ async def test_attendance_success(
         "4. UserC\n"
         "5. UserC +1"
     )
-    mock_interaction.response.send_message.assert_awaited_once_with(expected_output, ephemeral=True)
+    mock_interaction.followup.send.assert_awaited_once_with(expected_output, ephemeral=True)
     # 4. Check logs (optional)
     mock_log.warning.assert_not_called()
 
@@ -211,7 +212,7 @@ async def test_attendance_report_sends_csv_by_dm(
         f"Attendance report for **{event_name_target}** is attached as a CSV file.",
         file=mock_file,
     )
-    mock_interaction.response.send_message.assert_awaited_once_with(
+    mock_interaction.followup.send.assert_awaited_once_with(
         f"Attendance report for '{event_name_target}' has been sent to you by DM.",
         ephemeral=True,
     )
@@ -236,7 +237,7 @@ async def test_attendance_report_rejects_open_event(
 
     mock_has_complete_numbers.assert_not_called()
     mock_build_rows.assert_not_called()
-    mock_interaction.response.send_message.assert_awaited_once_with(
+    mock_interaction.followup.send.assert_awaited_once_with(
         "Attendee numbers are generated when an event is closed. Close the event before exporting this report.",
         ephemeral=True,
     )
@@ -261,7 +262,7 @@ async def test_attendance_report_rejects_incomplete_numbering(
     await EventsCog.attendance_report.callback(mock_cog, mock_interaction, event_name="Summer Bash")
 
     mock_build_rows.assert_not_called()
-    mock_interaction.response.send_message.assert_awaited_once_with(
+    mock_interaction.followup.send.assert_awaited_once_with(
         "Attendee numbers are generated when an event is closed. Close the event before exporting this report.",
         ephemeral=True,
     )
@@ -306,7 +307,7 @@ async def test_attendance_with_drinks(
         "2. Alice (UserA +1) - water\n"
         "3.   (UserB +1) - N/A"
     )
-    mock_interaction.response.send_message.assert_awaited_once_with(expected_output, ephemeral=True)
+    mock_interaction.followup.send.assert_awaited_once_with(expected_output, ephemeral=True)
     mock_log.warning.assert_not_called()
 
 
@@ -355,7 +356,7 @@ async def test_attendance_sort_success(
         "4. UserC\n"
         "5. UserC +1"
     )
-    mock_interaction.response.send_message.assert_awaited_once_with(expected_output, ephemeral=True)
+    mock_interaction.followup.send.assert_awaited_once_with(expected_output, ephemeral=True)
     # 4. Check logs (optional)
     mock_log.warning.assert_not_called()
 
@@ -409,7 +410,7 @@ async def test_attendance_long_output_under_100_sends_file_by_dm(
         f"Attendance for **{event_name_target}** is attached as a text file.",
         file=mock_file,
     )
-    mock_interaction.response.send_message.assert_awaited_once_with(
+    mock_interaction.followup.send.assert_awaited_once_with(
         f"Attendance list for '{event_name_target}' has been sent to you by DM.",
         ephemeral=True,
     )
@@ -461,7 +462,7 @@ async def test_attendance_over_100_sends_file_by_dm(
         f"Attendance for **{event_name_target}** is attached as a text file.",
         file=mock_file,
     )
-    mock_interaction.response.send_message.assert_awaited_once_with(
+    mock_interaction.followup.send.assert_awaited_once_with(
         f"Attendance list for '{event_name_target}' has been sent to you by DM.",
         ephemeral=True,
     )
@@ -514,7 +515,7 @@ async def test_attendance_over_100_with_drinks_sends_file_by_dm(
         f"Attendance for **{event_name_target}** is attached as a text file.",
         file=mock_file,
     )
-    mock_interaction.response.send_message.assert_awaited_once_with(
+    mock_interaction.followup.send.assert_awaited_once_with(
         f"Attendance list for '{event_name_target}' has been sent to you by DM.",
         ephemeral=True,
     )
@@ -562,7 +563,7 @@ async def test_attendance_over_100_falls_back_to_ephemeral_file_when_dm_fails(
         f"Attendance for **{event_name_target}** is attached as a text file.",
         file=dm_file,
     )
-    mock_interaction.response.send_message.assert_awaited_once_with(
+    mock_interaction.followup.send.assert_awaited_once_with(
         "I couldn't send you a DM, so I've attached the attendance list here.",
         file=fallback_file,
         ephemeral=True,
@@ -597,7 +598,7 @@ async def test_attendance_event_not_found(
     # Assert only get_event was called
     mock_get_event.assert_called_once_with(event_name_target)
     mock_calculate_attendance.assert_not_called()
-    mock_interaction.response.send_message.assert_not_awaited()
+    mock_interaction.followup.send.assert_not_awaited()
 
 
 @patch("offkai_bot.cogs.events.calculate_attendance")
@@ -631,7 +632,7 @@ async def test_attendance_no_responses_found(
     mock_calculate_attendance.assert_called_once_with(event_name_target, nicknames=False, drinks=False, sort=False)
 
     # Assert subsequent steps were NOT called
-    mock_interaction.response.send_message.assert_not_awaited()
+    mock_interaction.followup.send.assert_not_awaited()
 
 
 @patch("offkai_bot.cogs.events.calculate_attendance")
@@ -665,4 +666,4 @@ async def test_attendance_with_nicknames(
     mock_calculate_attendance.assert_called_once_with(event_name_target, nicknames=True, drinks=False, sort=False)
 
     expected_output = f"**Attendance for {event_name_target}**\n\nTotal Attendees: **2**\n\n1. foo (goo)\n2. bar"
-    mock_interaction.response.send_message.assert_awaited_once_with(expected_output, ephemeral=True)
+    mock_interaction.followup.send.assert_awaited_once_with(expected_output, ephemeral=True)

--- a/bot/tests/commands/test_broadcast.py
+++ b/bot/tests/commands/test_broadcast.py
@@ -53,7 +53,8 @@ def mock_interaction():
     # Mock response methods
     interaction.response = MagicMock()
     interaction.response.send_message = AsyncMock()
-    interaction.followup = MagicMock(send=AsyncMock())  # In case response is done
+    interaction.response.defer = AsyncMock()
+    interaction.followup = MagicMock(send=AsyncMock())
 
     return interaction
 
@@ -102,7 +103,7 @@ async def test_broadcast_success(
     # 3. Check sending message to thread
     mock_thread.send.assert_awaited_once_with(f"{broadcast_message}")
     # 4. Check final interaction response
-    mock_interaction.response.send_message.assert_awaited_once_with(
+    mock_interaction.followup.send.assert_awaited_once_with(
         f"📣 Sent broadcast to channel {mock_thread.mention}.", ephemeral=True
     )
     # 5. Check logs (optional)
@@ -140,7 +141,7 @@ async def test_broadcast_event_not_found(
     mock_get_event.assert_called_once_with(event_name)
     # Assert subsequent steps were NOT called
     mock_fetch_thread.assert_not_awaited()  # Check helper wasn't called
-    mock_interaction.response.send_message.assert_not_awaited()
+    mock_interaction.followup.send.assert_not_awaited()
 
 
 @patch("offkai_bot.cogs.events.fetch_thread_for_event", new_callable=AsyncMock)
@@ -178,7 +179,7 @@ async def test_broadcast_missing_channel_id(
     # Assert helper was called
     mock_fetch_thread.assert_awaited_once_with(ANY, target_event)
     # Assert subsequent steps were NOT called
-    mock_interaction.response.send_message.assert_not_awaited()
+    mock_interaction.followup.send.assert_not_awaited()
 
 
 @patch("offkai_bot.cogs.events.fetch_thread_for_event", new_callable=AsyncMock)
@@ -216,7 +217,7 @@ async def test_broadcast_thread_not_found_error(  # Renamed test slightly
     # Assert helper was called
     mock_fetch_thread.assert_awaited_once_with(ANY, target_event)
     # Assert subsequent steps were NOT called
-    mock_interaction.response.send_message.assert_not_awaited()
+    mock_interaction.followup.send.assert_not_awaited()
 
 
 @patch("offkai_bot.cogs.events.fetch_thread_for_event", new_callable=AsyncMock)
@@ -256,7 +257,7 @@ async def test_broadcast_thread_access_error(  # New test for access error
     # Assert helper was called
     mock_fetch_thread.assert_awaited_once_with(ANY, target_event)
     # Assert subsequent steps were NOT called
-    mock_interaction.response.send_message.assert_not_awaited()
+    mock_interaction.followup.send.assert_not_awaited()
 
 
 @patch("offkai_bot.cogs.events.fetch_thread_for_event", new_callable=AsyncMock)
@@ -300,7 +301,7 @@ async def test_broadcast_send_permission_error(
     # Assert send was called
     mock_thread.send.assert_awaited_once_with(f"{broadcast_message}")
     # Assert final response was NOT called
-    mock_interaction.response.send_message.assert_not_awaited()
+    mock_interaction.followup.send.assert_not_awaited()
 
 
 @patch("offkai_bot.cogs.events.fetch_thread_for_event", new_callable=AsyncMock)
@@ -344,4 +345,4 @@ async def test_broadcast_send_http_error(
     # Assert send was called
     mock_thread.send.assert_awaited_once_with(f"{broadcast_message}")
     # Assert final response was NOT called
-    mock_interaction.response.send_message.assert_not_awaited()
+    mock_interaction.followup.send.assert_not_awaited()

--- a/bot/tests/commands/test_close_offkai.py
+++ b/bot/tests/commands/test_close_offkai.py
@@ -43,6 +43,8 @@ def mock_interaction():
     # Mock response methods
     interaction.response = MagicMock()
     interaction.response.send_message = AsyncMock()
+    interaction.response.defer = AsyncMock()
+    interaction.followup = MagicMock(send=AsyncMock())
 
     # Simple mock client if needed, but not used for patching global state
     interaction.client = MagicMock(spec=discord.Client)
@@ -79,7 +81,7 @@ async def test_close_offkai_command_success_with_message(mock_perform_close, moc
     )
 
     # 2. Check that the interaction response was sent
-    mock_interaction.response.send_message.assert_awaited_once_with(
+    mock_interaction.followup.send.assert_awaited_once_with(
         f"✅ Responses for '{event_name_to_close}' have been closed."
     )
 
@@ -108,7 +110,7 @@ async def test_close_offkai_command_success_no_message(mock_perform_close, mock_
     )
 
     # 2. Check that the interaction response was sent
-    mock_interaction.response.send_message.assert_awaited_once_with(
+    mock_interaction.followup.send.assert_awaited_once_with(
         f"✅ Responses for '{event_name_to_close}' have been closed."
     )
 
@@ -142,4 +144,4 @@ async def test_close_offkai_command_error_propagation(mock_perform_close, mock_i
     )
 
     # Assert that the success response was NOT sent
-    mock_interaction.response.send_message.assert_not_awaited()
+    mock_interaction.followup.send.assert_not_awaited()

--- a/bot/tests/commands/test_create_offkai.py
+++ b/bot/tests/commands/test_create_offkai.py
@@ -59,6 +59,10 @@ def mock_interaction():
     # Mock response methods
     interaction.response = MagicMock()
     interaction.response.send_message = AsyncMock()
+    interaction.response.defer = AsyncMock()
+    # followup.send returns the announcement message, which the command pins
+    interaction.followup = MagicMock()
+    interaction.followup.send = AsyncMock(return_value=MagicMock(spec=discord.Message))
 
     # Mock the client instance attached to main (or bot in cog)
     # The cog uses self.bot, which is mocked in mock_cog.
@@ -188,7 +192,7 @@ async def test_create_offkai_success_sends_and_pins_message(
     # Assert: Verify the main command logic completed
     mock_add_event.assert_called_once()
     mock_register_reminders.assert_called_once()
-    mock_interaction.response.send_message.assert_awaited_once()
+    mock_interaction.followup.send.assert_awaited_once()
 
 
 @patch("offkai_bot.event_actions.save_event_data")
@@ -269,7 +273,7 @@ async def test_create_offkai_success_without_deadline_and_pins_message(
     # Assert: Verify the main command logic completed
     mock_add_event.assert_called_once()
     mock_register_reminders.assert_called_once()
-    mock_interaction.response.send_message.assert_awaited_once()
+    mock_interaction.followup.send.assert_awaited_once()
 
 
 @patch("offkai_bot.event_actions.save_event_data")
@@ -437,7 +441,7 @@ async def test_create_offkai_raises_pin_permission_error(
     mock_send_event_message.assert_awaited_once()
 
     # Assert that the final success message was NOT sent, because an error was raised
-    mock_interaction.response.send_message.assert_not_awaited()
+    mock_interaction.followup.send.assert_not_awaited()
 
 
 @patch("offkai_bot.cogs.events.send_event_message")
@@ -483,7 +487,7 @@ async def test_create_offkai_thread_creation_fails(
     # Assert that the function exited before trying to send or pin a message
     mock_add_event.assert_not_called()
     mock_send_msg.assert_not_awaited()
-    mock_interaction.response.send_message.assert_not_awaited()
+    mock_interaction.followup.send.assert_not_awaited()
 
 
 @patch("offkai_bot.cogs.events.get_event")
@@ -668,4 +672,4 @@ async def test_create_offkai_add_event_validation_fails(
 
     mock_add_event.assert_called_once()
     mock_send_msg.assert_not_awaited()
-    mock_interaction.response.send_message.assert_not_awaited()
+    mock_interaction.followup.send.assert_not_awaited()

--- a/bot/tests/commands/test_delete_response.py
+++ b/bot/tests/commands/test_delete_response.py
@@ -49,7 +49,8 @@ def mock_interaction():
     # Mock response methods
     interaction.response = MagicMock()
     interaction.response.send_message = AsyncMock()
-    interaction.followup = MagicMock(send=AsyncMock())  # In case response is done
+    interaction.response.defer = AsyncMock()
+    interaction.followup = MagicMock(send=AsyncMock())
 
     return interaction
 
@@ -117,7 +118,7 @@ async def test_delete_response_success(
     # 2. Check remove_response call
     mock_remove_response_func.assert_called_once_with(event_name_target, mock_member.id)
     # 3. Check interaction response
-    mock_interaction.response.send_message.assert_awaited_once_with(
+    mock_interaction.followup.send.assert_awaited_once_with(
         f"🚮 Deleted response from user {mock_member.mention} for '{event_name_target}'.",
         ephemeral=True,
     )
@@ -167,7 +168,7 @@ async def test_delete_response_success_no_channel_id(
     # Steps up to response should succeed
     mock_get_event.assert_called_once_with(event_name_target)
     mock_remove_response_func.assert_called_once_with(event_name_target, mock_member.id)
-    mock_interaction.response.send_message.assert_awaited_once()
+    mock_interaction.followup.send.assert_awaited_once()
 
     # Discord interactions should be skipped, warning logged
     mock_cog.bot.get_channel.assert_not_called()
@@ -212,7 +213,7 @@ async def test_delete_response_success_thread_not_found(
     # Steps up to response should succeed
     mock_get_event.assert_called_once_with(event_name_target)
     mock_remove_response_func.assert_called_once_with(event_name_target, mock_member.id)
-    mock_interaction.response.send_message.assert_awaited_once()
+    mock_interaction.followup.send.assert_awaited_once()
     mock_cog.bot.get_channel.assert_called_once_with(mock_event_obj.thread_id)
 
     # Removing user should be skipped, warning logged
@@ -260,7 +261,7 @@ async def test_delete_response_success_remove_user_fails(
     # Steps up to remove_user should succeed
     mock_get_event.assert_called_once_with(event_name_target)
     mock_remove_response_func.assert_called_once_with(event_name_target, mock_member.id)
-    mock_interaction.response.send_message.assert_awaited_once()
+    mock_interaction.followup.send.assert_awaited_once()
     mock_cog.bot.get_channel.assert_called_once_with(mock_event_obj.thread_id)
     mock_thread.remove_user.assert_awaited_once_with(mock_member)  # Should still be called
 
@@ -301,7 +302,7 @@ async def test_delete_response_event_not_found(
     # Assert only get_event was called
     mock_get_event.assert_called_once_with(event_name_target)
     mock_remove_response_func.assert_not_called()
-    mock_interaction.response.send_message.assert_not_awaited()
+    mock_interaction.followup.send.assert_not_awaited()
     mock_cog.bot.get_channel.assert_not_called()
 
 
@@ -344,6 +345,6 @@ async def test_delete_response_response_not_found_in_data(
     mock_remove_response_func.assert_called_once_with(event_name_target, mock_member.id)
 
     # Assert subsequent steps were NOT called
-    mock_interaction.response.send_message.assert_not_awaited()
+    mock_interaction.followup.send.assert_not_awaited()
     mock_cog.bot.get_channel.assert_not_called()
     mock_thread.remove_user.assert_not_awaited()  # Ensure thread removal wasn't attempted

--- a/bot/tests/commands/test_modify_offkai.py
+++ b/bot/tests/commands/test_modify_offkai.py
@@ -64,6 +64,8 @@ def mock_interaction():
     # Mock response methods
     interaction.response = MagicMock()
     interaction.response.send_message = AsyncMock()
+    interaction.response.defer = AsyncMock()
+    interaction.followup = MagicMock(send=AsyncMock())
 
     # Add client mock needed by fetch_thread_for_event
     interaction.client = MagicMock(spec=discord.Client)
@@ -164,7 +166,7 @@ async def test_modify_offkai_success(
     mock_update_msg_view.assert_awaited_once_with(ANY, mock_modified_event)
     mock_fetch_thread.assert_awaited_once_with(ANY, mock_modified_event)
     mock_thread.send.assert_awaited_once_with(f"**Event Updated:**\n{update_text}")
-    mock_interaction.response.send_message.assert_awaited_once_with(
+    mock_interaction.followup.send.assert_awaited_once_with(
         f"✅ Event '{event_name_to_modify}' modified successfully. Announcement posted in thread (if possible)."
     )
     mock_log.warning.assert_not_called()
@@ -240,7 +242,7 @@ async def test_modify_offkai_success_without_deadline_change(  # New test
     # 5. Check sending update message to thread
     mock_thread.send.assert_awaited_once_with(f"**Event Updated:**\n{update_text}")
     # 6. Check final interaction response
-    mock_interaction.response.send_message.assert_awaited_once_with(
+    mock_interaction.followup.send.assert_awaited_once_with(
         f"✅ Event '{event_name_to_modify}' modified successfully. Announcement posted in thread (if possible)."
     )
     mock_log.warning.assert_not_called()
@@ -317,7 +319,7 @@ async def test_modify_offkai_assigns_channel_id_if_missing(
     mock_thread.send.assert_awaited_once_with(f"**Event Updated:**\n{update_text}")
 
     # Verify final response
-    mock_interaction.response.send_message.assert_awaited_once_with(
+    mock_interaction.followup.send.assert_awaited_once_with(
         f"✅ Event '{event_name_to_modify}' modified successfully. Announcement posted in thread (if possible)."
     )
 
@@ -396,7 +398,7 @@ async def test_modify_offkai_data_layer_errors(
     mock_save_data.assert_not_called()
     mock_update_msg_view.assert_not_awaited()
     mock_fetch_thread.assert_not_awaited()  # Check helper wasn't called
-    mock_interaction.response.send_message.assert_not_awaited()
+    mock_interaction.followup.send.assert_not_awaited()
 
 
 # Test handling errors from fetch_thread_for_event
@@ -470,7 +472,7 @@ async def test_modify_offkai_fetch_thread_errors(
     assert log_call[2] == event_name_to_modify
 
     # Final confirmation should still be sent
-    mock_interaction.response.send_message.assert_awaited_once_with(
+    mock_interaction.followup.send.assert_awaited_once_with(
         f"✅ Event '{event_name_to_modify}' modified successfully. Announcement posted in thread (if possible)."
     )
 
@@ -527,7 +529,7 @@ async def test_modify_offkai_send_update_fails(
     assert mock_log.warning.call_args[0][1] == mock_thread.id
 
     # Final confirmation should still be sent
-    mock_interaction.response.send_message.assert_awaited_once_with(
+    mock_interaction.followup.send.assert_awaited_once_with(
         f"✅ Event '{event_name_to_modify}' modified successfully. Announcement posted in thread (if possible)."
     )
 
@@ -587,7 +589,7 @@ async def test_modify_offkai_increase_capacity_success(
     mock_update_msg_view.assert_awaited_once_with(ANY, event_after_update)
     mock_fetch_thread.assert_awaited_once_with(ANY, event_after_update)
     mock_thread.send.assert_awaited_once_with(f"**Event Updated:**\n{update_text}")
-    mock_interaction.response.send_message.assert_awaited_once_with(
+    mock_interaction.followup.send.assert_awaited_once_with(
         f"✅ Event '{event_name_to_modify}' modified successfully. Announcement posted in thread (if possible)."
     )
 
@@ -644,7 +646,7 @@ async def test_modify_offkai_decrease_capacity_success(
     mock_update_msg_view.assert_awaited_once_with(ANY, event_after_update)
     mock_fetch_thread.assert_awaited_once_with(ANY, event_after_update)
     mock_thread.send.assert_awaited_once_with(f"**Event Updated:**\n{update_text}")
-    mock_interaction.response.send_message.assert_awaited_once_with(
+    mock_interaction.followup.send.assert_awaited_once_with(
         f"✅ Event '{event_name_to_modify}' modified successfully. Announcement posted in thread (if possible)."
     )
 

--- a/bot/tests/commands/test_promote.py
+++ b/bot/tests/commands/test_promote.py
@@ -40,6 +40,7 @@ def mock_interaction():
 
     interaction.response = MagicMock()
     interaction.response.send_message = AsyncMock()
+    interaction.response.defer = AsyncMock()
     interaction.followup = MagicMock(send=AsyncMock())
 
     return interaction
@@ -114,9 +115,9 @@ async def test_promote_success(
     assert added_response.user_id == 99999
     assert added_response.username == "waitlistuser"
 
-    mock_interaction.response.send_message.assert_awaited_once()
-    assert "Promoted user" in mock_interaction.response.send_message.call_args[0][0]
-    assert mock_interaction.response.send_message.call_args[1]["ephemeral"] is True
+    mock_interaction.followup.send.assert_awaited_once()
+    assert "Promoted user" in mock_interaction.followup.send.call_args[0][0]
+    assert mock_interaction.followup.send.call_args[1]["ephemeral"] is True
 
     mock_cog.bot.fetch_user.assert_awaited_once_with(99999)
     mock_promoted_user.send.assert_awaited_once()
@@ -158,7 +159,7 @@ async def test_promote_dm_failure(
     # Promotion should still succeed
     mock_promote_specific.assert_called_once()
     mock_add_response_for_event.assert_called_once()
-    mock_interaction.response.send_message.assert_awaited_once()
+    mock_interaction.followup.send.assert_awaited_once()
     mock_update_event_msg.assert_awaited_once()
 
     # DM failure should be logged as warning
@@ -188,7 +189,7 @@ async def test_promote_event_not_found(
 
     mock_get_event.assert_called_once_with("NonExistent")
     mock_promote_specific.assert_not_called()
-    mock_interaction.response.send_message.assert_not_awaited()
+    mock_interaction.followup.send.assert_not_awaited()
 
 
 @patch("offkai_bot.cogs.events.add_response_for_event")
@@ -217,7 +218,7 @@ async def test_promote_user_not_on_waitlist(
 
     mock_promote_specific.assert_called_once_with("Summer Bash", 99999)
     mock_add_response_for_event.assert_not_called()
-    mock_interaction.response.send_message.assert_not_awaited()
+    mock_interaction.followup.send.assert_not_awaited()
 
 
 @patch("offkai_bot.cogs.events.promote_specific_from_waitlist")
@@ -241,7 +242,7 @@ async def test_promote_invalid_username(
     )
 
     mock_promote_specific.assert_not_called()
-    mock_interaction.response.send_message.assert_awaited_once()
-    call_args = mock_interaction.response.send_message.call_args
+    mock_interaction.followup.send.assert_awaited_once()
+    call_args = mock_interaction.followup.send.call_args
     assert "Invalid user selection" in call_args[0][0]
     assert call_args[1]["ephemeral"] is True

--- a/bot/tests/commands/test_reopen_offkai.py
+++ b/bot/tests/commands/test_reopen_offkai.py
@@ -55,6 +55,8 @@ def mock_interaction():
     # Mock response methods
     interaction.response = MagicMock()
     interaction.response.send_message = AsyncMock()
+    interaction.response.defer = AsyncMock()
+    interaction.followup = MagicMock(send=AsyncMock())
 
     return interaction
 
@@ -124,7 +126,7 @@ async def test_reopen_offkai_success_with_message(
     # Check sending reopening message to thread
     mock_thread.send.assert_awaited_once_with(f"**Responses Reopened:**\n{reopen_text}")
     # Check final interaction response
-    mock_interaction.response.send_message.assert_awaited_once_with(
+    mock_interaction.followup.send.assert_awaited_once_with(
         f"✅ Responses for '{event_name_to_reopen}' have been reopened."
     )
     mock_log.warning.assert_not_called()
@@ -171,7 +173,7 @@ async def test_reopen_offkai_success_no_message(
     # Check sending reopening message was NOT called
     mock_thread.send.assert_not_awaited()
     # Check final interaction response
-    mock_interaction.response.send_message.assert_awaited_once_with(
+    mock_interaction.followup.send.assert_awaited_once_with(
         f"✅ Responses for '{event_name_to_reopen}' have been reopened."
     )
     mock_log.warning.assert_not_called()
@@ -222,7 +224,7 @@ async def test_reopen_offkai_data_layer_errors(
     mock_save_data.assert_not_called()
     mock_update_msg_view.assert_not_awaited()
     mock_fetch_thread.assert_not_awaited()  # Check helper wasn't called
-    mock_interaction.response.send_message.assert_not_awaited()
+    mock_interaction.followup.send.assert_not_awaited()
 
 
 # --- UPDATED TEST ---
@@ -273,7 +275,7 @@ async def test_reopen_offkai_fetch_thread_not_found_error(  # Renamed test
     assert log_call_args[2] == event_name_to_reopen
 
     # Final confirmation should still be sent
-    mock_interaction.response.send_message.assert_awaited_once_with(
+    mock_interaction.followup.send.assert_awaited_once_with(
         f"✅ Responses for '{event_name_to_reopen}' have been reopened."
     )
 
@@ -326,7 +328,7 @@ async def test_reopen_offkai_fetch_thread_missing_id_error(
     assert log_call_args[1] == "Could not send reopening message for event '%s': %s"
     assert log_call_args[2] == event_name_to_reopen
 
-    mock_interaction.response.send_message.assert_awaited_once_with(
+    mock_interaction.followup.send.assert_awaited_once_with(
         f"✅ Responses for '{event_name_to_reopen}' have been reopened."
     )
 
@@ -379,7 +381,7 @@ async def test_reopen_offkai_fetch_thread_access_error(
     assert log_call_args[1] == "Could not send reopening message for event '%s': %s"
     assert log_call_args[2] == event_name_to_reopen
 
-    mock_interaction.response.send_message.assert_awaited_once_with(
+    mock_interaction.followup.send.assert_awaited_once_with(
         f"✅ Responses for '{event_name_to_reopen}' have been reopened."
     )
 
@@ -440,6 +442,6 @@ async def test_reopen_offkai_send_reopen_msg_fails(
     assert mock_log.warning.call_args[0][1] == mock_thread.id
 
     # Final confirmation should still be sent
-    mock_interaction.response.send_message.assert_awaited_once_with(
+    mock_interaction.followup.send.assert_awaited_once_with(
         f"✅ Responses for '{event_name_to_reopen}' have been reopened."
     )


### PR DESCRIPTION
Fixes #99

## Problem

Slash-command interactions must be acknowledged within 3 seconds, but none of the events cog commands called `interaction.response.defer()`. Commands that hit the Discord API before responding — `create_offkai` (thread/role creation, event message send + pin) and `modify_offkai` (waitlist promotion that fetches and DMs every promoted user) being the worst — could blow the window. The organizer would see "The application did not respond" and the global error handler's own response would fail with `Unknown interaction` (10062), even though the command's side effects actually happened.

## Changes

- Every command in `cogs/events.py` that performs network work before its confirmation now defers up front:
  - **Public confirmations** (`create_offkai`, `modify_offkai`, `close_offkai`, `reopen_offkai`, `archive_offkai`) defer non-ephemerally.
  - **Ephemeral confirmations** (`broadcast`, `delete_response`, `promote`, `attendance`, `attendance_report`) defer with `ephemeral=True`.
- Final confirmations switched from `interaction.response.send_message(...)` to `interaction.followup.send(...)`.
- `create_offkai` pins the message returned by `followup.send(..., wait=True)` instead of calling `interaction.original_response()`.
- `waitlist` and `drinks` are untouched — they respond immediately from in-memory data.
- No change needed in `main.py`: the global error handler already branches on `interaction.response.is_done()` and sends via followup when the interaction was deferred, and the `PinPermissionError` path already used `followup`.
- Updated the 9 affected command test files: interaction fixtures gained `defer`/`followup.send` AsyncMocks, and assertions now target `followup.send`.

## Testing

- `uv run pytest bot/tests` — 512 passed
- `uvx ruff check --fix .`, `uvx ruff format .`, `uvx ty check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)