### PR TITLE
fix(alerts): sweep overdue alert keys and wait for gateway before loop starts

### DIFF
--- a/bot/src/offkai_bot/alerts/alerts.py
+++ b/bot/src/offkai_bot/alerts/alerts.py
@@ -3,6 +3,7 @@ import logging
 from collections.abc import Callable
 from datetime import datetime
 
+import discord
 from discord.ext import tasks  # type: ignore[attr-defined]
 
 # Import necessary components from your project
@@ -14,6 +15,9 @@ _log = logging.getLogger(__name__)
 
 # --- Storage for Scheduled Tasks ---
 _scheduled_tasks: dict[str, list[Task]] = {}
+
+# Client the loop waits on before its first tick; set by start_alert_loop().
+_client: discord.Client | None = None
 
 # --- Key Format String ---
 _TIME_KEY_FORMAT = "%Y-%m-%dT%H:%M"
@@ -86,53 +90,56 @@ def remove_alerts(predicate: Callable[[Task], bool]) -> int:
     return removed
 
 
-# --- NEW: Helper function processes tasks based on a given time ---
+# --- Helper function processes tasks based on a given time ---
 async def fire_alert(current_time: datetime):
     """
-    Calculates the time key for the given current_time, looks up tasks,
-    executes them, and removes them from the schedule.
+    Executes and removes every scheduled task whose time key is at or before
+    current_time. Sweeping all due keys (rather than exact-matching the current
+    minute) means a loop tick that fires late or skips a minute catches up on
+    missed alerts instead of silently dropping them.
 
     Args:
         current_time: The timezone-aware datetime object (expected to be JST)
                       representing the current time to check for tasks.
-        client: The discord client instance.
     """
     global _scheduled_tasks
 
     # --- Generate Key from the provided time ---
-    key = current_time.strftime(_TIME_KEY_FORMAT)
-    _log.debug("Processing tasks for time key (JST): %s", key)
+    now_key = current_time.strftime(_TIME_KEY_FORMAT)
+    _log.debug("Processing tasks for time key (JST): %s", now_key)
 
-    # --- Check for Tasks Scheduled for this specific time key ---
-    tasks_to_process = _scheduled_tasks.get(key)
+    # Keys in _TIME_KEY_FORMAT sort lexicographically in chronological order,
+    # so a plain string comparison finds everything due.
+    due_keys = sorted(key for key in _scheduled_tasks if key <= now_key)
 
-    if not tasks_to_process:
-        _log.debug("No tasks scheduled for %s.", key)
-        return  # Nothing to do for this key
+    if not due_keys:
+        _log.debug("No tasks scheduled for %s.", now_key)
+        return  # Nothing due
 
-    _log.info("Found %s tasks scheduled for %s. Executing...", len(tasks_to_process), key)
-
-    # --- Execute Tasks ---
-    for task in tasks_to_process:
-        # Ensure the task has the client instance if it needs it
-        if not hasattr(task, "client") or task.client is None:
-            _log.warning("Task %s for %s is missing client instance. Skipping.", type(task).__name__, key)
+    for key in due_keys:
+        # Pop the bucket before executing so a task that mutates the schedule
+        # (or a concurrent sweep) can't double-fire it.
+        tasks_to_process = _scheduled_tasks.pop(key, None)
+        if not tasks_to_process:
             continue
 
-        try:
-            _log.debug("Executing task: %s (%s)", type(task).__name__, getattr(task, "event_name", "N/A"))
-            await task.action()
-        except Exception as task_exec_err:
-            # Log errors during the execution of a specific task's action
-            _log.exception("Error executing task %s for key %s: %s", type(task).__name__, key, task_exec_err)
+        _log.info("Found %s tasks scheduled for %s. Executing...", len(tasks_to_process), key)
 
-    # --- Remove Executed Tasks ---
-    # Remove the key from the dictionary after processing all tasks for that minute
-    removed_tasks_list = _scheduled_tasks.pop(key, None)
-    if removed_tasks_list:
-        _log.info("Removed %s executed tasks for key %s.", len(removed_tasks_list), key)
-    else:
-        _log.warning("Attempted to remove tasks for key %s, but key was not found (potentially already removed).", key)
+        # --- Execute Tasks ---
+        for task in tasks_to_process:
+            # Ensure the task has the client instance if it needs it
+            if not hasattr(task, "client") or task.client is None:
+                _log.warning("Task %s for %s is missing client instance. Skipping.", type(task).__name__, key)
+                continue
+
+            try:
+                _log.debug("Executing task: %s (%s)", type(task).__name__, getattr(task, "event_name", "N/A"))
+                await task.action()
+            except Exception as task_exec_err:
+                # Log errors during the execution of a specific task's action
+                _log.exception("Error executing task %s for key %s: %s", type(task).__name__, key, task_exec_err)
+
+        _log.info("Removed %s executed tasks for key %s.", len(tasks_to_process), key)
 
 
 # --- Refactored alert_loop ---
@@ -159,7 +166,19 @@ async def alert_loop():
 @alert_loop.before_loop
 async def before_alert_loop():
     _log.info("Alert loop starting...")
-    # Rely on setup_hook finishing before the loop starts naturally.
+    # Don't tick until the gateway is connected and the cache is populated —
+    # otherwise tasks resolve channels/users to None and alerts are consumed
+    # without ever being delivered.
+    if _client is not None:
+        await _client.wait_until_ready()
+
+
+def start_alert_loop(client: discord.Client):
+    """Starts the alert loop, holding onto the client so the loop can wait for
+    the gateway to be ready before its first tick."""
+    global _client
+    _client = client
+    alert_loop.start()
 
 
 # Optional error handler for the loop task itself

--- a/bot/src/offkai_bot/main.py
+++ b/bot/src/offkai_bot/main.py
@@ -10,7 +10,7 @@ from discord.ext import commands
 
 # --- Updated Imports ---
 from offkai_bot import config
-from offkai_bot.alerts.alerts import alert_loop
+from offkai_bot.alerts.alerts import start_alert_loop
 from offkai_bot.alerts.reminders import register_checkin_reminder, register_deadline_reminders
 from offkai_bot.config import get_config
 
@@ -95,7 +95,7 @@ class OffkaiClient(commands.Bot):
         _log.info("Commands synced.")
 
         await load_and_update_events(self)
-        alert_loop.start()
+        start_alert_loop(self)
 
 
 intents = discord.Intents.default()

--- a/bot/tests/alerts/test_fire_alerts.py
+++ b/bot/tests/alerts/test_fire_alerts.py
@@ -169,6 +169,110 @@ async def test_fire_alert_task_no_client(mock_log, mock_client):
 
 
 @patch("offkai_bot.alerts.alerts._log")
+async def test_fire_alert_sweeps_past_due_keys(mock_log, mock_client):
+    """Test fire_alert executes tasks keyed to earlier minutes (missed ticks), not just the current one."""
+    # Arrange
+    current_time = datetime(3024, 8, 15, 12, 30, 0, tzinfo=JST)
+    past_task = MagicMock(spec=Task, client=mock_client)
+    past_task.action = AsyncMock()
+    past_task.__class__.__name__ = "PastTask"
+    current_task = MagicMock(spec=Task, client=mock_client)
+    current_task.action = AsyncMock()
+    current_task.__class__.__name__ = "CurrentTask"
+
+    past_key = datetime(3024, 8, 15, 12, 27, 0, tzinfo=JST).strftime(alerts._TIME_KEY_FORMAT)
+    current_key = current_time.strftime(alerts._TIME_KEY_FORMAT)
+    alerts._scheduled_tasks[past_key] = [past_task]
+    alerts._scheduled_tasks[current_key] = [current_task]
+
+    # Act
+    await alerts.fire_alert(current_time)
+
+    # Assert
+    past_task.action.assert_awaited_once()
+    current_task.action.assert_awaited_once()
+    assert past_key not in alerts._scheduled_tasks
+    assert current_key not in alerts._scheduled_tasks
+
+
+@patch("offkai_bot.alerts.alerts._log")
+async def test_fire_alert_leaves_future_keys(mock_log, mock_client):
+    """Test fire_alert does not execute tasks scheduled for future minutes."""
+    # Arrange
+    current_time = datetime(3024, 8, 15, 12, 30, 0, tzinfo=JST)
+    future_task = MagicMock(spec=Task, client=mock_client)
+    future_task.action = AsyncMock()
+    future_task.__class__.__name__ = "FutureTask"
+
+    future_key = datetime(3024, 8, 15, 12, 31, 0, tzinfo=JST).strftime(alerts._TIME_KEY_FORMAT)
+    alerts._scheduled_tasks[future_key] = [future_task]
+
+    # Act
+    await alerts.fire_alert(current_time)
+
+    # Assert
+    future_task.action.assert_not_awaited()
+    assert future_key in alerts._scheduled_tasks
+
+
+@patch("offkai_bot.alerts.alerts._log")
+async def test_fire_alert_sweeps_in_chronological_order(mock_log, mock_client):
+    """Test overdue buckets execute oldest-first when several minutes are due at once."""
+    # Arrange
+    current_time = datetime(3024, 8, 15, 12, 30, 0, tzinfo=JST)
+    call_order = []
+
+    def make_task(name):
+        task = MagicMock(spec=Task, client=mock_client)
+        task.action = AsyncMock(side_effect=lambda name=name: call_order.append(name))
+        task.__class__.__name__ = name
+        return task
+
+    # Insert out of chronological order on purpose.
+    late_key = datetime(3024, 8, 15, 12, 29, 0, tzinfo=JST).strftime(alerts._TIME_KEY_FORMAT)
+    early_key = datetime(3024, 8, 15, 12, 25, 0, tzinfo=JST).strftime(alerts._TIME_KEY_FORMAT)
+    alerts._scheduled_tasks[late_key] = [make_task("late")]
+    alerts._scheduled_tasks[early_key] = [make_task("early")]
+
+    # Act
+    await alerts.fire_alert(current_time)
+
+    # Assert
+    assert call_order == ["early", "late"]
+    assert not alerts._scheduled_tasks
+
+
+# --- Tests for loop startup ---
+
+
+async def test_before_alert_loop_waits_until_ready():
+    """Test before_alert_loop waits for the gateway when a client is registered."""
+    mock_client = MagicMock(spec=discord.Client)
+    mock_client.wait_until_ready = AsyncMock()
+
+    with patch.object(alerts, "_client", mock_client):
+        await alerts.before_alert_loop()
+
+    mock_client.wait_until_ready.assert_awaited_once()
+
+
+async def test_before_alert_loop_without_client():
+    """Test before_alert_loop does not blow up when no client was registered."""
+    with patch.object(alerts, "_client", None):
+        await alerts.before_alert_loop()  # Should simply not raise
+
+
+async def test_start_alert_loop_registers_client_and_starts_loop():
+    """Test start_alert_loop stores the client and starts the tasks.loop."""
+    mock_client = MagicMock(spec=discord.Client)
+
+    with patch.object(alerts.alert_loop, "start") as mock_start, patch.object(alerts, "_client", None):
+        alerts.start_alert_loop(mock_client)
+        assert alerts._client is mock_client
+        mock_start.assert_called_once()
+
+
+@patch("offkai_bot.alerts.alerts._log")
 async def test_fire_alert_triggers_on_different_seconds(mock_log, mock_client, mock_task):
     """Test fire_alert triggers tasks registered for a minute, even if called with different seconds."""
     # Arrange


### PR DESCRIPTION
Fixes two ways scheduled alerts could be silently lost. Closes #100.

## Problem

1. **Exact-minute matching drops alerts.** `fire_alert` only executed tasks whose key exactly equaled the current tick's `%Y-%m-%dT%H:%M`. Since `tasks.loop(minutes=1.0)` can drift or skip a minute under load, any alert keyed to a skipped minute never fired and sat in `_scheduled_tasks` forever — e.g. an auto-close (`CloseOffkaiTask`) that missed its minute meant the event never closed, with no error anywhere.
2. **Startup race.** `alert_loop.start()` ran in `setup_hook` before the gateway connected, and `before_alert_loop` didn't wait for readiness. A tick firing before the cache was populated made tasks resolve channels to `None` — and the alert was still consumed and removed.

## Fix

- `fire_alert` now sweeps **all keys `<=` the current minute** (keys in `%Y-%m-%dT%H:%M` format sort lexicographically, so this is a plain string comparison), processing buckets oldest-first. A late tick catches up instead of dropping work. Each bucket is popped *before* execution so a task that mutates the schedule (or a concurrent sweep) can't double-fire it.
- The loop is now started via a new `start_alert_loop(client)`, which stores the client so `before_alert_loop` can `await client.wait_until_ready()` before the first tick.

## Tests

Added six tests in `bot/tests/alerts/test_fire_alerts.py`:
- past-due keys fire on a later tick; future keys are left untouched
- multiple overdue buckets execute in chronological order
- `before_alert_loop` awaits `wait_until_ready()` when a client is registered, and doesn't raise when none is
- `start_alert_loop` stores the client and starts the loop

All quality gates pass: `ruff check`, `ruff format`, `ty check`, and the full suite (538 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)