### PR TITLE
fix: fail closed on check-in URLs when ADMIN_KEY is unset

### DIFF
--- a/bot/src/offkai_bot/main.py
+++ b/bot/src/offkai_bot/main.py
@@ -86,6 +86,8 @@ class OffkaiClient(commands.Bot):
 
         if not get_config().get("FRONTEND_URL"):
             _log.warning("FRONTEND_URL is not set — check-in URLs will be omitted from DMs.")
+        elif not get_config().get("ADMIN_KEY"):
+            _log.warning("ADMIN_KEY is not set — check-in URLs cannot be signed and will be omitted from DMs.")
 
         # Sync commands
         for guild_id in settings["GUILDS"]:

--- a/bot/src/offkai_bot/util.py
+++ b/bot/src/offkai_bot/util.py
@@ -177,18 +177,19 @@ def build_checkin_token(user_id: int, event_name: str, secret_key: str) -> str:
 
 def build_checkin_url(user_id: int, event_name: str) -> str:
     """Returns the attendee's personal, event-bound check-in URL, or '' if
-    FRONTEND_URL is not configured.
+    FRONTEND_URL or ADMIN_KEY is not configured.
 
-    With ADMIN_KEY set, emits a signed v2 token bound to ``event_name`` so the
-    link can only ever resolve to that event. Without a key, falls back to the
-    bare user_id that the keyless frontend accepts. Centralises token
+    Emits a signed v2 token bound to ``event_name`` so the link can only ever
+    resolve to that event. Without ADMIN_KEY there is no way to sign the token,
+    so no link is emitted at all (fail closed — a bare user_id token would be
+    forgeable, since Discord user IDs are public). Centralises token
     construction so the three call sites (signup, waitlist promotion, reminder)
     stay in sync.
     """
     settings = get_config()
     frontend_url = settings.get("FRONTEND_URL", "")
-    if not frontend_url:
-        return ""
     admin_key = settings.get("ADMIN_KEY", "")
-    token = build_checkin_token(user_id, event_name, admin_key) if admin_key else str(user_id)
+    if not frontend_url or not admin_key:
+        return ""
+    token = build_checkin_token(user_id, event_name, admin_key)
     return f"{frontend_url}/?token={token}"

--- a/bot/tests/test_util.py
+++ b/bot/tests/test_util.py
@@ -358,11 +358,10 @@ def test_build_checkin_url_no_frontend_url(mock_get_config):
 
 
 @patch("offkai_bot.util.get_config")
-def test_build_checkin_url_no_admin_key_uses_bare_user_id(mock_get_config):
-    """Without ADMIN_KEY the token is just the bare user_id (keyless frontend)."""
+def test_build_checkin_url_no_admin_key_returns_empty(mock_get_config):
+    """Without ADMIN_KEY no URL is emitted (fail closed — a bare user_id token is forgeable)."""
     mock_get_config.return_value = {"FRONTEND_URL": "https://offkai.example", "ADMIN_KEY": ""}
-    result = build_checkin_url(99, "Summer Bash")
-    assert result == "https://offkai.example/?token=99"
+    assert build_checkin_url(99, "Summer Bash") == ""
 
 
 @patch("offkai_bot.util.get_config")
@@ -381,5 +380,5 @@ def test_build_checkin_url_missing_keys_default_to_empty(mock_get_config):
     """Keys absent from config dict are treated as empty strings — no KeyError."""
     mock_get_config.return_value = {"FRONTEND_URL": "https://offkai.example"}
     result = build_checkin_url(7, "Summer Bash")
-    # No ADMIN_KEY → bare user_id token.
-    assert result == "https://offkai.example/?token=7"
+    # No ADMIN_KEY → fail closed, no URL.
+    assert result == ""

--- a/frontend/app/api/token.ts
+++ b/frontend/app/api/token.ts
@@ -45,11 +45,10 @@ export function verifyToken(raw: string): ResolvedToken | null {
   if (typeof raw !== 'string' || !raw || raw.length > MAX_TOKEN_LEN) return null
   const token = raw.trim()
 
-  // Without a configured key we cannot verify signatures (dev/mock without key).
-  // Treat a bare numeric value as the user id; reject anything signed.
-  if (!ADMIN_KEY) {
-    return /^\d+$/.test(token) ? { userId: token, eventName: null } : null
-  }
+  // Without a configured key we cannot verify signatures, so no token is
+  // acceptable (fail closed — a bare user_id would be forgeable, since
+  // Discord user IDs are public; issue #101).
+  if (!ADMIN_KEY) return null
 
   const parts = token.split('.')
 


### PR DESCRIPTION
## Summary

Fixes #101.

When `ADMIN_KEY` was empty, `build_checkin_url` fell back to emitting `?token=<user_id>` and the frontend accepted that bare form — but Discord user IDs are public, so anyone in the server could forge another attendee's check-in link. Forgetting one env var silently downgraded all check-in links to unauthenticated.

This PR makes the whole path fail closed:

- **`bot/src/offkai_bot/util.py`** — `build_checkin_url` returns `""` when `ADMIN_KEY` is empty (the same way a missing `FRONTEND_URL` already disables links), so DMs simply omit the link instead of including a forgeable one. All three call sites (signup confirmation, waitlist promotion, check-in reminder) already handle the empty string.
- **`bot/src/offkai_bot/main.py`** — startup warning when `FRONTEND_URL` is set but `ADMIN_KEY` is not, matching the existing `FRONTEND_URL` warning, so the misconfiguration is visible instead of silent.
- **`frontend/app/api/token.ts`** — `verifyToken` now rejects all tokens when `ADMIN_KEY` is unset, removing the keyless bare-numeric acceptance path.

Legacy signed `<user_id>.<sig>` tokens still verify; per the issue, retiring those is deferred until existing links expire.

## Testing

- `uv run pytest bot/tests` — 532 passed; the two `build_checkin_url` tests that asserted the keyless fallback now assert fail-closed behavior.
- `uvx ruff check` / `uvx ruff format` / `uvx ty check` — clean.
- `npm run lint --prefix frontend` and `npm run build --prefix frontend` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)