### PR TITLE
fix: suppress all mentions by default, opt in only where pings are intended

### DIFF
--- a/bot/src/offkai_bot/alerts/reminders.py
+++ b/bot/src/offkai_bot/alerts/reminders.py
@@ -77,6 +77,13 @@ def register_deadline_reminders(client: discord.Client, event: Event, thread: di
 
             if event.channel_id:
                 role_ping = f"<@&{event.ping_role_id}> " if event.ping_role_id else ""
+                # The client-wide default suppresses all mentions; opt back in for
+                # just the configured ping role so the reminder actually notifies.
+                reminder_mentions = (
+                    discord.AllowedMentions(roles=[discord.Object(id=event.ping_role_id)])
+                    if event.ping_role_id
+                    else None
+                )
 
                 register_alert(
                     event.event_deadline - timedelta(days=1),
@@ -88,6 +95,7 @@ def register_deadline_reminders(client: discord.Client, event: Event, thread: di
                         f"See {thread.mention} for details.\n"
                         f"{event.event_name}の登録締切まであと24時間です！"
                         f"詳細は{thread.mention}をご覧ください。",
+                        allowed_mentions=reminder_mentions,
                     ),
                 )
                 _log.info("Registered 24 hour reminder for '%s'.", event.event_name)
@@ -102,6 +110,7 @@ def register_deadline_reminders(client: discord.Client, event: Event, thread: di
                         f"See {thread.mention} for details.\n"
                         f"{event.event_name}の登録締切まであと3日です！"
                         f"詳細は{thread.mention}をご覧ください。",
+                        allowed_mentions=reminder_mentions,
                     ),
                 )
                 _log.info("Registered 3 day reminder for '%s'.", event.event_name)
@@ -116,6 +125,7 @@ def register_deadline_reminders(client: discord.Client, event: Event, thread: di
                         f"See {thread.mention} for details.\n"
                         f"{event.event_name}の登録締切まであと1週間です！"
                         f"詳細は{thread.mention}をご覧ください。",
+                        allowed_mentions=reminder_mentions,
                     ),
                 )
 

--- a/bot/src/offkai_bot/alerts/task.py
+++ b/bot/src/offkai_bot/alerts/task.py
@@ -35,6 +35,9 @@ class SendMessageTask(Task):
     # Optional tag linking this message to an event, so pending reminders can be
     # unregistered when the event's deadline changes or the event is archived.
     event_name: str | None = None
+    # Per-message mention opt-in. None keeps the client-wide AllowedMentions.none()
+    # default, so a task message can never ping unless it explicitly asks to.
+    allowed_mentions: discord.AllowedMentions | None = None
 
     async def action(self):
         """Sends the defined message to the specified channel."""
@@ -43,7 +46,12 @@ class SendMessageTask(Task):
             channel = self.client.get_channel(self.channel_id)
             # Use isinstance with a tuple for multiple types
             if isinstance(channel, discord.TextChannel | discord.Thread):
-                await channel.send(self.message)
+                # send()'s overloads reject allowed_mentions=None, so only pass the
+                # kwarg when this task opted in; omitting it keeps the client default.
+                if self.allowed_mentions is not None:
+                    await channel.send(self.message, allowed_mentions=self.allowed_mentions)
+                else:
+                    await channel.send(self.message)
             elif channel is None:
                 _log.warning("SendMessageTask: Channel %s not found.", self.channel_id)
             else:

--- a/bot/src/offkai_bot/cogs/general.py
+++ b/bot/src/offkai_bot/cogs/general.py
@@ -11,7 +11,11 @@ class GeneralCog(commands.Cog):
     @app_commands.checks.has_role("Offkai Organizer")
     async def hello(self, interaction: discord.Interaction):
         """Says hello!"""
-        await interaction.response.send_message(f"Hi, {interaction.user.mention}")
+        # Opt in to the user ping past the client-wide AllowedMentions.none() default.
+        await interaction.response.send_message(
+            f"Hi, {interaction.user.mention}",
+            allowed_mentions=discord.AllowedMentions(users=True),
+        )
 
 
 async def setup(bot: commands.Bot):

--- a/bot/src/offkai_bot/interactions.py
+++ b/bot/src/offkai_bot/interactions.py
@@ -410,7 +410,12 @@ class GatheringModal(ui.Modal):
                 rank = get_rank(interaction.user.name)
                 if rank in MILESTONE_MESSAGES and can_rank_message_sent(interaction.user.name):
                     msg_template = random.choice(MILESTONE_MESSAGES[rank])
-                    await interaction.channel.send(msg_template.format(user_id=interaction.user.id))
+                    # Milestone messages congratulate the user by mention; opt in to
+                    # user pings past the client-wide AllowedMentions.none() default.
+                    await interaction.channel.send(
+                        msg_template.format(user_id=interaction.user.id),
+                        allowed_mentions=discord.AllowedMentions(users=True),
+                    )
                     mark_achieved_rank(interaction.user.name)
 
         except (discord.Forbidden, discord.HTTPException):

--- a/bot/src/offkai_bot/main.py
+++ b/bot/src/offkai_bot/main.py
@@ -66,7 +66,15 @@ async def load_and_update_events(client: discord.Client):
 class OffkaiClient(commands.Bot):
     def __init__(self, *, intents: discord.Intents):
         # Initialize commands.Bot. Command prefix is required but we only use slash commands.
-        super().__init__(command_prefix="!", intents=intents, help_command=None)
+        # Suppress all mentions by default: organizer-supplied text (broadcast/update/close/
+        # announce messages) is relayed verbatim, and must not let the bot ping
+        # @everyone/@here/roles. Intended pings opt in per-send via allowed_mentions.
+        super().__init__(
+            command_prefix="!",
+            intents=intents,
+            help_command=None,
+            allowed_mentions=discord.AllowedMentions.none(),
+        )
 
     async def setup_hook(self):
         # Load extensions (Cogs)

--- a/bot/tests/alerts/test_register_alerts.py
+++ b/bot/tests/alerts/test_register_alerts.py
@@ -311,6 +311,9 @@ def test_register_deadline_reminders_with_ping_role(
         assert task.message.startswith(role_ping_prefix), (
             f"Expected message to start with role ping, got: {task.message}"
         )
+        # The reminder must opt in to pinging exactly the configured role.
+        assert task.allowed_mentions is not None
+        assert [role.id for role in task.allowed_mentions.roles] == [99887766]
 
 
 @patch("offkai_bot.alerts.reminders.register_alert")
@@ -333,6 +336,9 @@ def test_register_deadline_reminders_without_ping_role(
     for call in send_msg_calls:
         task = call[0][1]
         assert not task.message.startswith("<@&"), f"Expected no role ping, got: {task.message}"
+        # No ping role configured -> no mention opt-in; the client-wide
+        # AllowedMentions.none() default applies.
+        assert task.allowed_mentions is None
 
 
 @patch("offkai_bot.alerts.reminders.register_alert")  # <-- CORRECTED PATCH PATH

--- a/bot/tests/test_allowed_mentions.py
+++ b/bot/tests/test_allowed_mentions.py
@@ -1,0 +1,39 @@
+# tests/test_allowed_mentions.py
+"""Tests for the client-wide mention suppression default (issue #102).
+
+Organizer-supplied text (broadcast/update/close/announce messages) is relayed
+verbatim by the bot, so the client must default to AllowedMentions.none() and
+individual sends must explicitly opt in where a ping is intended.
+"""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import discord
+from discord.ext import commands
+from offkai_bot.cogs.general import GeneralCog
+from offkai_bot.main import OffkaiClient
+
+
+def test_client_suppresses_all_mentions_by_default():
+    """The client must be constructed with AllowedMentions.none() so relayed
+    organizer text can never ping @everyone/@here/roles/users."""
+    client = OffkaiClient(intents=discord.Intents.default())
+
+    assert client.allowed_mentions is not None
+    assert client.allowed_mentions.to_dict() == discord.AllowedMentions.none().to_dict()
+
+
+async def test_hello_opts_into_user_mentions():
+    """/hello greets the invoking user by mention and must opt in to user pings."""
+    cog = GeneralCog(MagicMock(spec=commands.Bot))
+    interaction = MagicMock(spec=discord.Interaction)
+    interaction.user = MagicMock()
+    interaction.user.mention = "<@42>"
+    interaction.response = MagicMock()
+    interaction.response.send_message = AsyncMock()
+
+    await cog.hello.callback(cog, interaction)
+
+    interaction.response.send_message.assert_awaited_once()
+    kwargs = interaction.response.send_message.await_args.kwargs
+    assert kwargs["allowed_mentions"].users is True

--- a/bot/tests/test_task.py
+++ b/bot/tests/test_task.py
@@ -96,6 +96,28 @@ async def test_send_message_task_success_thread(mock_log, mock_client, mock_thre
 
 
 @patch("offkai_bot.alerts.task._log")
+async def test_send_message_task_passes_allowed_mentions(mock_log, mock_client, mock_text_channel):
+    """Test SendMessageTask forwards an explicit allowed_mentions opt-in to send."""
+    # Arrange
+    channel_id = mock_text_channel.id
+    message_content = "<@&123> Reminder!"
+    mentions = discord.AllowedMentions(roles=[discord.Object(id=123)])
+    task = SendMessageTask(
+        client=mock_client,
+        channel_id=channel_id,
+        message=message_content,
+        allowed_mentions=mentions,
+    )
+    mock_client.get_channel.return_value = mock_text_channel
+
+    # Act
+    await task.action()
+
+    # Assert
+    mock_text_channel.send.assert_awaited_once_with(message_content, allowed_mentions=mentions)
+
+
+@patch("offkai_bot.alerts.task._log")
 async def test_send_message_task_channel_not_found(mock_log, mock_client):
     """Test SendMessageTask handles channel not found."""
     # Arrange


### PR DESCRIPTION
## Summary

Fixes #102.

The client was constructed without an `allowed_mentions` default, so every `channel.send`/`thread.send` resolved mentions. Since `/broadcast`, `update_msg`, `close_msg`, `announce_msg`, and `reopen_msg` relay organizer-supplied text verbatim, anyone with the "Offkai Organizer" role could make the **bot** ping `@everyone`/`@here`/any role anywhere the bot can speak — a privilege escalation from organizer permissions to bot permissions.

## Changes

- **`main.py`** — construct `OffkaiClient` with `allowed_mentions=discord.AllowedMentions.none()`, suppressing all mentions bot-wide by default.
- **`alerts/task.py`** — `SendMessageTask` gains an optional `allowed_mentions` field, forwarded to `channel.send()` only when set (the `send` overloads reject an explicit `None`; omitting the kwarg falls back to the client default).
- **`alerts/reminders.py`** — deadline reminders opt back in to pinging exactly the configured `ping_role_id` via `AllowedMentions(roles=[discord.Object(id=...)])`. Per-send values merge with the client default, so every other mention category stays suppressed.
- **`interactions.py`** — milestone messages opt in to user mentions (`AllowedMentions(users=True)`).
- **`cogs/general.py`** — the `/hello` reply opts in to user mentions.

Creator-withdrawal notifications and check-in reminders are DMs, where ping suppression has no user-facing effect, so they need no opt-in.

## Tests

- New `bot/tests/test_allowed_mentions.py`: asserts the client-wide `AllowedMentions.none()` default and the `/hello` user-mention opt-in.
- `test_task.py`: new test that `SendMessageTask` forwards an explicit `allowed_mentions` to `send()`.
- `test_register_alerts.py`: reminder tasks now asserted to opt in to exactly the configured ping role (and to no mentions when no ping role is set).

All gates pass: `uvx ruff check`, `uvx ty check`, `uv run pytest bot/tests` (535 passed). Frontend untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)