### PR TITLE
Validate new event datetime against existing deadline in /modify_offkai

### DIFF
--- a/bot/src/offkai_bot/data/event.py
+++ b/bot/src/offkai_bot/data/event.py
@@ -475,7 +475,8 @@ def update_event_details(
         # This will raise InvalidDateTimeFormatError immediately if parsing fails
         parsed_datetime = parse_event_datetime(date_time_str)
         validate_event_datetime(parsed_datetime)
-        validate_event_deadline(parsed_datetime, parsed_deadline)
+        # If the deadline isn't being changed, the new datetime must still respect the existing one
+        validate_event_deadline(parsed_datetime, parsed_deadline if deadline_str is not None else event.event_deadline)
     else:
         validate_event_deadline(event.event_datetime, parsed_deadline)
 

--- a/bot/tests/data/test_event.py
+++ b/bot/tests/data/test_event.py
@@ -1079,6 +1079,29 @@ def test_update_event_details_fails_deadline_after_new_event_time(mock_log, mock
     mock_save.assert_not_called()
 
 
+@patch("offkai_bot.data.event.get_event", return_value=copy.deepcopy(BASE_EVENT_OBJ))
+@patch("offkai_bot.data.event.parse_drinks", return_value=[])
+@patch("offkai_bot.data.event.save_event_data")
+@patch("offkai_bot.data.event._log")
+def test_update_event_details_fails_new_event_time_before_existing_deadline(
+    mock_log, mock_save, mock_parse_drinks, mock_get
+):
+    """Test update raises DeadlineAfterEventError when only the datetime moves before the existing deadline."""
+    # New event time is in the future but *before* the existing deadline (FUTURE_DEADLINE_BEFORE_EVENT)
+    new_earlier_event_time = FUTURE_DEADLINE_BEFORE_EVENT - timedelta(days=1)
+
+    with (
+        patch("offkai_bot.data.event.parse_event_datetime", return_value=new_earlier_event_time) as mock_parse_dt,
+        pytest.raises(EventDeadlineAfterEventError),
+    ):
+        event_data.update_event_details(
+            event_name=BASE_EVENT_OBJ.event_name,
+            date_time_str="new-earlier-event-time",  # No deadline_str: existing deadline must still be validated
+        )
+    mock_parse_dt.assert_called_once_with("new-earlier-event-time")
+    mock_save.assert_not_called()
+
+
 @patch("offkai_bot.data.event.get_event", return_value=copy.deepcopy(BASE_EVENT_OBJ))  # max_capacity=None
 @patch("offkai_bot.data.event.get_waitlist", return_value=[])
 @patch("offkai_bot.data.event.get_responses")


### PR DESCRIPTION
## Summary

Fixes #103.

In `update_event_details`, when `/modify_offkai` was given only a new `date_time`, the deadline check ran with `parsed_deadline=None`, which `validate_event_deadline` treats as a no-op. The event's **existing** deadline was never checked against the new datetime, so an event could be moved to start *before* its own signup deadline — leaving auto-close firing after the event already happened and `PostDeadlineEvent`/`OpenEvent` view selection inconsistent.

## Fix

When `date_time_str` is provided without a new `deadline_str`, fall back to the event's current `event_deadline` for validation (as suggested in the issue):

```python
validate_event_deadline(parsed_datetime, parsed_deadline if deadline_str is not None else event.event_deadline)
```

**Behavioral note:** if an event's deadline has already passed, changing only the event date now raises `EventDeadlineInPastError` — the organizer must supply a new deadline in the same command. This seems correct, since the alternative silently leaves the event in an inconsistent state.

## Testing

- Added `test_update_event_details_fails_new_event_time_before_existing_deadline` covering the exact failure scenario from the issue (new datetime earlier than the untouched existing deadline).
- `uvx ruff check` / `uvx ruff format` clean, `uvx ty check` clean, `uv run pytest bot/tests` — 533 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)