### PR TITLE
fix: stop repeating capacity announcement on every waitlist signup

### DIFF
--- a/bot/src/offkai_bot/interactions.py
+++ b/bot/src/offkai_bot/interactions.py
@@ -609,13 +609,6 @@ class GatheringModal(ui.Modal):
                 # Send waitlist confirmation
                 await self._handle_waitlist_submission(interaction, new_entry)
 
-                # Check if this is the first time capacity was reached - send thread message
-                # Only send this if capacity just reached (not if deadline passed or event closed)
-                if at_capacity and not is_past_deadline and not is_closed:
-                    current_count = get_current_attendance_count(self.event.event_name)
-                    if current_count == self.event.max_capacity:
-                        await self._send_capacity_reached_message(interaction)
-
             elif would_exceed_capacity(self.event, total_people_in_group):
                 # Registration would exceed capacity - add to waitlist with special message
                 remaining = get_remaining_capacity(self.event)

--- a/bot/tests/commands/test_capacity_waitlist.py
+++ b/bot/tests/commands/test_capacity_waitlist.py
@@ -797,6 +797,59 @@ async def test_capacity_reached_message_sent_when_filling_event(event_with_capac
 
 
 @pytest.mark.asyncio
+async def test_capacity_reached_message_not_repeated_on_waitlist_signup(
+    event_with_capacity, mock_interaction, mock_cog
+):
+    """Waitlist signups while the event sits at capacity must not re-post the capacity announcement."""
+    # Fill the event to exactly max capacity (3)
+    add_response(
+        event_with_capacity.event_name,
+        Response(
+            user_id=999,
+            username="ExistingUser",
+            extra_people=2,  # 3 people total
+            behavior_confirmed=True,
+            arrival_confirmed=True,
+            event_name=event_with_capacity.event_name,
+            timestamp=datetime.now(UTC),
+            drinks=[],
+        ),
+    )
+
+    # Two more users sign up while at capacity - both go to the waitlist
+    for user_id in (123, 456):
+        interaction = MagicMock(spec=discord.Interaction)
+        interaction.user = MagicMock(spec=discord.Member)
+        interaction.user.id = user_id
+        interaction.user.name = f"WaitlistUser{user_id}"
+        interaction.user.send = AsyncMock()
+        interaction.channel = MagicMock(spec=discord.Thread)
+        interaction.channel.id = 456
+        interaction.channel.send = AsyncMock()
+        interaction.channel.add_user = AsyncMock()
+        interaction.response = MagicMock()
+        interaction.response.send_message = AsyncMock()
+
+        modal = GatheringModal(event=event_with_capacity)
+        modal.extra_people_input = MagicMock()
+        modal.extra_people_input.value = "0"
+        modal.behave_checkbox_input = MagicMock()
+        modal.behave_checkbox_input.value = "Yes"
+        modal.arrival_checkbox_input = MagicMock()
+        modal.arrival_checkbox_input.value = "Yes"
+        modal.drink_choice_input = None
+        modal.extras_names_input = MagicMock()
+        modal.extras_names_input.value = ""
+
+        await modal.on_submit(interaction)
+
+        # User was waitlisted, but no announcement was posted to the thread
+        assert not interaction.channel.send.called
+
+    assert len(get_waitlist(event_with_capacity.event_name)) == 2
+
+
+@pytest.mark.asyncio
 async def test_waitlist_dm_contains_extra_charge_warning(event_with_capacity, mock_interaction, mock_cog):
     """Test that waitlist DM contains the extra-charge warning."""
     # Fill the event to capacity


### PR DESCRIPTION
## Summary
Fixes #104.

When an event sat exactly at `max_capacity`, every subsequent waitlist signup re-posted the "⚠️ Maximum capacity has been reached!" announcement to the thread — the waitlist branch in `GatheringModal.on_submit` checked `current_count == max_capacity` with no latch, and joining the waitlist never changes the attendance count.

## Fix
Remove the announcement from the waitlist branch entirely. The confirmed-registration branch already posts the announcement at the exact moment a registration fills the last spot, which is the only time it should fire.

## Testing
- Added `test_capacity_reached_message_not_repeated_on_waitlist_signup`: fills an event to capacity, then verifies two subsequent waitlist signups produce no thread announcement (both signups still land on the waitlist).
- Existing `test_capacity_reached_message_sent_when_filling_event` still passes, confirming the announcement fires when the last spot is filled.
- `uvx ruff check`, `uvx ty check`, and the full suite (533 tests) all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)