### PR TITLE
fix: promote waitlist to match freed headcount for unlimited-capacity events

### DIFF
--- a/bot/src/offkai_bot/data/response.py
+++ b/bot/src/offkai_bot/data/response.py
@@ -606,8 +606,8 @@ def add_response(
     return assigned_max_number
 
 
-def remove_response(event_name: str, user_id: int) -> None:
-    """Removes a response for a given user from the specified event's attendees.
+def remove_response(event_name: str, user_id: int) -> Response:
+    """Removes and returns the response for a given user from the specified event's attendees.
 
     Raises:
         ResponseNotFoundError: If no response is found for the given user and event.
@@ -628,6 +628,7 @@ def remove_response(event_name: str, user_id: int) -> None:
         all_data[event_name] = event_data
         save_responses()
         _log.info("Removed response from user %s for event %s.", user_id, event_name)
+        return removed_response
 
 
 def add_to_waitlist(event_name: str, entry: WaitlistEntry) -> None:

--- a/bot/src/offkai_bot/interactions.py
+++ b/bot/src/offkai_bot/interactions.py
@@ -94,14 +94,18 @@ def get_remaining_capacity(event: Event) -> int | None:
     return max(0, event.max_capacity - current_count)
 
 
-async def promote_waitlist_batch(event: Event, client: discord.Client) -> list[int]:
+async def promote_waitlist_batch(event: Event, client: discord.Client, freed_spots: int | None = None) -> list[int]:
     """
     Promote users from waitlist to fill available capacity.
+
+    For events without a target capacity (unlimited capacity and never closed),
+    freed_spots bounds the promotion to the headcount freed by a withdrawal so
+    the confirmed total stays stable. If freed_spots is also None, there is no
+    constraint to protect and the entire waitlist is promoted.
 
     Returns list of promoted user IDs.
     """
     promoted_user_ids: list[int] = []
-    promoted_count = 0
 
     # Resolve guild for role assignment
     guild: discord.Guild | None = None
@@ -124,13 +128,15 @@ async def promote_waitlist_batch(event: Event, client: discord.Client) -> list[i
         # Event is still open or was never closed, use max_capacity
         target_capacity = event.max_capacity
 
+    if target_capacity is None and freed_spots is not None:
+        # Unlimited capacity, but a withdrawal freed a specific headcount:
+        # backfill exactly that many spots so the confirmed total stays stable.
+        target_capacity = get_current_attendance_count(event.event_name) + freed_spots
+
     while True:
         # Check if we should continue promoting
-        if target_capacity is None:
-            # No capacity limit, only promote one person (original behavior for unlimited events)
-            if promoted_count >= 1:
-                break
-        else:
+        # (if target_capacity is None there is no constraint: drain the whole waitlist)
+        if target_capacity is not None:
             # Check if we're at target capacity
             current_count = get_current_attendance_count(event.event_name)
             if current_count >= target_capacity:
@@ -169,7 +175,6 @@ async def promote_waitlist_batch(event: Event, client: discord.Client) -> list[i
             display_name=promoted_entry.display_name,
         )
         add_response_for_event(event, promoted_response)
-        promoted_count += 1
         promoted_user_ids.append(promoted_entry.user_id)
 
         # Assign event participant role
@@ -733,11 +738,13 @@ class OpenEvent(EventView):
     )
     async def withdraw(self, interaction: discord.Interaction, button: discord.ui.Button):
         removed_from_responses = False
+        freed_spots = 0
         try:
             # Try to remove from responses first
-            remove_response(self.event.event_name, interaction.user.id)
+            removed_response = remove_response(self.event.event_name, interaction.user.id)
             decrease_rank(interaction.user.name)
             removed_from_responses = True
+            freed_spots = 1 + removed_response.extra_people
 
         except ResponseNotFoundError:
             # User not in responses, try waitlist
@@ -808,7 +815,7 @@ class OpenEvent(EventView):
             # 6. Promote users from the waitlist only if removed from responses
             # (not from waitlist, since that doesn't free up capacity)
             if removed_from_responses:
-                await promote_waitlist_batch(self.event, interaction.client)
+                await promote_waitlist_batch(self.event, interaction.client, freed_spots=freed_spots)
 
         except Exception as e:
             # Catch any errors during notification/promotion
@@ -855,10 +862,12 @@ class ClosedEvent(EventView):
     )
     async def withdraw(self, interaction: discord.Interaction, button: discord.ui.Button):
         removed_from_responses = False
+        freed_spots = 0
         try:
             # Try to remove from responses first
-            remove_response(self.event.event_name, interaction.user.id)
+            removed_response = remove_response(self.event.event_name, interaction.user.id)
             removed_from_responses = True
+            freed_spots = 1 + removed_response.extra_people
 
         except ResponseNotFoundError:
             # User not in responses, try waitlist
@@ -959,7 +968,7 @@ class ClosedEvent(EventView):
             # 6. Promote users from the waitlist only if removed from responses
             # (not from waitlist, since that doesn't free up capacity)
             if removed_from_responses:
-                await promote_waitlist_batch(self.event, interaction.client)
+                await promote_waitlist_batch(self.event, interaction.client, freed_spots=freed_spots)
 
         except Exception as e:
             # Catch any errors during notification/promotion
@@ -996,10 +1005,12 @@ class PostDeadlineEvent(EventView):
     )
     async def withdraw(self, interaction: discord.Interaction, button: discord.ui.Button):
         removed_from_responses = False
+        freed_spots = 0
         try:
             # Try to remove from responses first
-            remove_response(self.event.event_name, interaction.user.id)
+            removed_response = remove_response(self.event.event_name, interaction.user.id)
             removed_from_responses = True
+            freed_spots = 1 + removed_response.extra_people
 
         except ResponseNotFoundError:
             # User not in responses, try waitlist
@@ -1100,7 +1111,7 @@ class PostDeadlineEvent(EventView):
             # 6. Promote users from the waitlist only if removed from responses
             # (not from waitlist, since that doesn't free up capacity)
             if removed_from_responses:
-                await promote_waitlist_batch(self.event, interaction.client)
+                await promote_waitlist_batch(self.event, interaction.client, freed_spots=freed_spots)
 
         except Exception as e:
             # Catch any errors during notification/promotion

--- a/bot/tests/commands/test_unlimited_waitlist_promotion.py
+++ b/bot/tests/commands/test_unlimited_waitlist_promotion.py
@@ -1,0 +1,219 @@
+"""Tests for waitlist promotion on unlimited-capacity events (issue #108)."""
+
+from datetime import UTC, datetime, timedelta
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from offkai_bot.data.event import Event
+from offkai_bot.data.response import Response, WaitlistEntry, add_response, add_to_waitlist, get_responses, get_waitlist
+from offkai_bot.interactions import PostDeadlineEvent, get_current_attendance_count, promote_waitlist_batch
+
+from offkai_bot.data import event as event_data
+from offkai_bot.data import response as response_data
+
+
+@pytest.fixture(autouse=True)
+def clear_test_caches(mock_paths):
+    """Clear caches and files before each test in this module."""
+    import json
+    import os
+
+    # Clear caches
+    event_data.EVENT_DATA_CACHE = None
+    response_data.RESPONSE_DATA_CACHE = None
+
+    # Initialize the temp files
+    for file_path in [mock_paths["events"], mock_paths["responses"]]:
+        if file_path:
+            os.makedirs(os.path.dirname(file_path), exist_ok=True)
+            if "events" in file_path:
+                with open(file_path, "w") as f:
+                    json.dump([], f)
+            else:
+                with open(file_path, "w") as f:
+                    json.dump({}, f)
+
+    yield
+
+    # Clean up after test
+    event_data.EVENT_DATA_CACHE = None
+    response_data.RESPONSE_DATA_CACHE = None
+
+
+@pytest.fixture
+def unlimited_event_past_deadline():
+    """Unlimited-capacity event whose deadline has passed but is still open."""
+    now = datetime.now(UTC)
+    return Event(
+        event_name="Unlimited Test Event",
+        venue="Test Venue",
+        address="Test Address",
+        google_maps_link="test_link",
+        event_datetime=now + timedelta(days=30),
+        event_deadline=now - timedelta(days=1),  # Deadline in the past
+        channel_id=456,
+        thread_id=111,
+        message_id=None,
+        open=True,
+        archived=False,
+        drinks=[],
+        max_capacity=None,  # Unlimited
+        creator_id=999,
+    )
+
+
+def _add_attendee(event_name: str, user_id: int, extra_people: int = 0):
+    add_response(
+        event_name,
+        Response(
+            user_id=user_id,
+            username=f"User{user_id}",
+            extra_people=extra_people,
+            behavior_confirmed=True,
+            arrival_confirmed=True,
+            event_name=event_name,
+            timestamp=datetime.now(UTC),
+            drinks=[],
+        ),
+    )
+
+
+def _add_waitlisted(event_name: str, user_id: int, extra_people: int = 0):
+    add_to_waitlist(
+        event_name,
+        WaitlistEntry(
+            user_id=user_id,
+            username=f"WaitlistUser{user_id}",
+            extra_people=extra_people,
+            behavior_confirmed=True,
+            arrival_confirmed=True,
+            event_name=event_name,
+            timestamp=datetime.now(UTC),
+            drinks=[],
+        ),
+    )
+
+
+def _make_withdraw_interaction(user_id: int):
+    mock_interaction = MagicMock()
+    mock_interaction.user = MagicMock()
+    mock_interaction.user.id = user_id
+    mock_interaction.user.name = f"User{user_id}"
+    mock_interaction.user.send = AsyncMock()
+    mock_interaction.channel = MagicMock()
+    mock_interaction.channel.remove_user = AsyncMock()
+    mock_interaction.response = MagicMock()
+    mock_interaction.response.send_message = AsyncMock()
+    mock_interaction.client = MagicMock()
+    mock_interaction.client.fetch_user = AsyncMock(return_value=MagicMock(send=AsyncMock()))
+    return mock_interaction
+
+
+def _make_mock_client():
+    client = MagicMock()
+    client.fetch_user = AsyncMock(return_value=MagicMock(send=AsyncMock()))
+    return client
+
+
+@pytest.mark.asyncio
+async def test_group_withdrawal_promotes_matching_headcount(unlimited_event_past_deadline):
+    """
+    A party of 6 withdrawing from an unlimited event frees 6 spots,
+    so 6 waitlisted people (not just 1 group) are promoted.
+    """
+    event = unlimited_event_past_deadline
+
+    # Party of 6 (1 + 5 extras) plus 4 solo attendees
+    _add_attendee(event.event_name, 100, extra_people=5)
+    for i in range(4):
+        _add_attendee(event.event_name, 101 + i)
+
+    # 8 solo people join the waitlist after the deadline
+    for i in range(8):
+        _add_waitlisted(event.event_name, 200 + i)
+
+    assert get_current_attendance_count(event.event_name) == 10
+
+    view = PostDeadlineEvent(event)
+    await view.withdraw.callback(_make_withdraw_interaction(100))
+
+    responses = get_responses(event.event_name)
+    waitlist = get_waitlist(event.event_name)
+
+    # 6 spots freed -> 6 promoted, headcount back to 10, 2 still waiting
+    assert get_current_attendance_count(event.event_name) == 10
+    assert len(responses) == 10  # 4 original + 6 promoted
+    assert len(waitlist) == 2
+    promoted_ids = {r.user_id for r in responses if r.user_id >= 200}
+    assert promoted_ids == {200, 201, 202, 203, 204, 205}  # FIFO order
+
+
+@pytest.mark.asyncio
+async def test_solo_withdrawal_promotes_single_group(unlimited_event_past_deadline):
+    """A solo withdrawal from an unlimited event still promotes exactly one solo group."""
+    event = unlimited_event_past_deadline
+
+    for i in range(3):
+        _add_attendee(event.event_name, 100 + i)
+    for i in range(3):
+        _add_waitlisted(event.event_name, 200 + i)
+
+    view = PostDeadlineEvent(event)
+    await view.withdraw.callback(_make_withdraw_interaction(100))
+
+    responses = get_responses(event.event_name)
+    waitlist = get_waitlist(event.event_name)
+
+    assert get_current_attendance_count(event.event_name) == 3
+    assert any(r.user_id == 200 for r in responses)  # First in line promoted
+    assert len(waitlist) == 2
+
+
+@pytest.mark.asyncio
+async def test_group_withdrawal_promotes_whole_waitlist_when_smaller(unlimited_event_past_deadline):
+    """If fewer people are waitlisted than spots freed, the whole waitlist is promoted."""
+    event = unlimited_event_past_deadline
+
+    _add_attendee(event.event_name, 100, extra_people=5)  # Party of 6
+    _add_waitlisted(event.event_name, 200)
+    _add_waitlisted(event.event_name, 201)
+
+    view = PostDeadlineEvent(event)
+    await view.withdraw.callback(_make_withdraw_interaction(100))
+
+    responses = get_responses(event.event_name)
+    assert {r.user_id for r in responses} == {200, 201}
+    assert len(get_waitlist(event.event_name)) == 0
+
+
+@pytest.mark.asyncio
+async def test_promotion_stops_when_next_group_exceeds_freed_spots(unlimited_event_past_deadline):
+    """A group larger than the freed headcount is not promoted (FIFO order preserved)."""
+    event = unlimited_event_past_deadline
+
+    _add_attendee(event.event_name, 100)  # Solo attendee
+    _add_waitlisted(event.event_name, 200, extra_people=2)  # Party of 3, first in line
+    _add_waitlisted(event.event_name, 201)  # Solo, second in line
+
+    view = PostDeadlineEvent(event)
+    await view.withdraw.callback(_make_withdraw_interaction(100))
+
+    # Only 1 spot freed; the party of 3 doesn't fit and promotion stops rather
+    # than skipping ahead to the solo entry behind it.
+    assert get_responses(event.event_name) == []
+    assert len(get_waitlist(event.event_name)) == 2
+
+
+@pytest.mark.asyncio
+async def test_promote_batch_without_freed_spots_drains_waitlist(unlimited_event_past_deadline):
+    """With no capacity target and no freed-spot bound, the whole waitlist is promoted."""
+    event = unlimited_event_past_deadline
+
+    for i in range(5):
+        _add_waitlisted(event.event_name, 200 + i, extra_people=i % 3)
+
+    promoted = await promote_waitlist_batch(event, _make_mock_client())
+
+    assert len(promoted) == 5
+    assert len(get_waitlist(event.event_name)) == 0
+    assert len(get_responses(event.event_name)) == 5


### PR DESCRIPTION
## Summary

Fixes #108.

`promote_waitlist_batch` promoted exactly **one** waitlist group when an event had no target capacity (unlimited capacity and never closed), regardless of how many spots a withdrawal freed. If a party of 6 withdrew from an unlimited-capacity event past its deadline, only the next single waitlist group was promoted — everyone else stayed waitlisted until further withdrawals trickled them in.

## Chosen semantics

Of the two options raised in the issue, this PR **matches the total headcount freed by the withdrawal** rather than promoting the whole waitlist. The post-deadline waitlist exists to keep the confirmed headcount stable at what the organizer committed to (e.g. to a venue), so backfilling exactly the freed spots preserves that; draining the entire waitlist on any withdrawal would blow past it.

## Changes

- `data/response.py`: `remove_response` now returns the removed `Response` so callers know the departing party's size.
- `interactions.py`: all three withdraw handlers (`OpenEvent`, `ClosedEvent`, `PostDeadlineEvent`) pass `freed_spots = 1 + extra_people` to `promote_waitlist_batch`.
- `interactions.py`: `promote_waitlist_batch` accepts `freed_spots` and, when there is no target capacity, converts it into a virtual target (`current count + freed_spots`) so the existing capacity-fill loop is reused — FIFO order, group-fit checks, and stop-when-the-next-group-doesn't-fit all behave identically to the capacity-limited path. With no capacity target *and* no freed-spot bound (currently unreachable from any caller), the whole waitlist is promoted since there is genuinely no constraint to protect.
- Removed the now-dead `promoted_count` counter.

## Tests

New `bot/tests/commands/test_unlimited_waitlist_promotion.py` covering:
- Party of 6 withdraws → 6 waitlisted people promoted (FIFO), headcount stable.
- Solo withdrawal → exactly one solo group promoted (previous common-case behavior preserved).
- Freed spots exceed waitlist size → whole waitlist promoted.
- Next group larger than freed spots → promotion stops without skipping ahead (matches capacity-limited FIFO behavior).
- Direct `promote_waitlist_batch` call with no bound → waitlist drained.

All 537 bot tests pass; `ruff` and `ty` are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)