### PR TITLE
Validate event name length in /create_offkai

### DIFF
--- a/bot/src/offkai_bot/cogs/events.py
+++ b/bot/src/offkai_bot/cogs/events.py
@@ -64,6 +64,7 @@ from offkai_bot.util import (
     parse_event_datetime,
     validate_event_datetime,
     validate_event_deadline,
+    validate_event_name,
     validate_interaction_context,
 )
 
@@ -172,6 +173,7 @@ class EventsCog(commands.Cog):
         create_role: bool = False,
     ):
         # 1. Business Logic Validation
+        validate_event_name(event_name)
         with contextlib.suppress(EventNotFoundError):
             if get_event(event_name):
                 raise DuplicateEventError(event_name)

--- a/bot/src/offkai_bot/errors.py
+++ b/bot/src/offkai_bot/errors.py
@@ -198,6 +198,18 @@ class EventDeadlineAfterEventError(BotCommandError):
         super().__init__("❌ Event deadline must be set *before* the event date/time.")
 
 
+class EventNameTooLongError(BotCommandError):
+    """Raised when the provided event name exceeds the maximum allowed length."""
+
+    def __init__(self, event_name: str, max_length: int):
+        self.event_name = event_name
+        self.max_length = max_length
+        super().__init__(
+            f"❌ Event name is too long ({len(event_name)} characters). "
+            f"Please use a name with at most {max_length} characters."
+        )
+
+
 class CapacityReductionError(BotCommandError):
     """Raised when trying to reduce capacity below current attendee count."""
 

--- a/bot/src/offkai_bot/interactions.py
+++ b/bot/src/offkai_bot/interactions.py
@@ -209,6 +209,19 @@ async def promote_waitlist_batch(event: Event, client: discord.Client) -> list[i
     return promoted_user_ids
 
 
+# Discord's modal title cap is smaller than the custom_id cap, so a name that
+# fits "modal_<event_name>" (see MAX_EVENT_NAME_LENGTH) can still be too long
+# to display as the modal's title. Truncate the title only; custom_id keeps
+# the full event name for identity.
+MODAL_TITLE_MAX_LENGTH = 45
+
+
+def _build_modal_title(event_name: str) -> str:
+    if len(event_name) <= MODAL_TITLE_MAX_LENGTH:
+        return event_name
+    return event_name[: MODAL_TITLE_MAX_LENGTH - 1] + "…"
+
+
 # Class to handle the modal for event attendance
 class GatheringModal(ui.Modal):
     def __init__(
@@ -218,7 +231,7 @@ class GatheringModal(ui.Modal):
         timeout=None,
     ):
         super().__init__(
-            title=event.event_name,
+            title=_build_modal_title(event.event_name),
             timeout=timeout,
             custom_id=f"modal_{event.event_name}",
         )

--- a/bot/src/offkai_bot/util.py
+++ b/bot/src/offkai_bot/util.py
@@ -16,6 +16,7 @@ from offkai_bot.errors import (
     EventDateTimeInPastError,
     EventDeadlineAfterEventError,
     EventDeadlineInPastError,
+    EventNameTooLongError,
     InvalidChannelTypeError,
     InvalidDateTimeFormatError,
 )
@@ -63,6 +64,30 @@ def parse_drinks(drinks_str: str | None) -> list[str]:
     if not drinks_str:
         return []
     return [d.strip() for d in drinks_str.split(",") if d.strip()]
+
+
+# Discord caps both thread names and component/modal custom_ids at 100 characters.
+# The event name is embedded in the modal custom_id as "modal_<event_name>" (6-char
+# prefix), so the hard ceiling is 94; 90 leaves a little headroom.
+MAX_EVENT_NAME_LENGTH = 90
+
+
+def validate_event_name(event_name: str):
+    """
+    Validates that the event name fits within Discord's thread-name and
+    modal custom_id limits.
+
+    Raises:
+        EventNameTooLongError: If the event name exceeds MAX_EVENT_NAME_LENGTH.
+    """
+    if len(event_name) > MAX_EVENT_NAME_LENGTH:
+        _log.info(
+            "Validation failed: Event name length %d exceeds maximum %d.",
+            len(event_name),
+            MAX_EVENT_NAME_LENGTH,
+        )
+        raise EventNameTooLongError(event_name, MAX_EVENT_NAME_LENGTH)
+    _log.debug("Validation success: Event name length %d is within limit.", len(event_name))
 
 
 def validate_interaction_context(interaction: discord.Interaction):

--- a/bot/tests/commands/test_create_offkai.py
+++ b/bot/tests/commands/test_create_offkai.py
@@ -15,13 +15,14 @@ from offkai_bot.errors import (
     EventDateTimeInPastError,
     EventDeadlineAfterEventError,
     EventDeadlineInPastError,
+    EventNameTooLongError,
     EventNotFoundError,  # Needed for mocking get_event side effect
     InvalidChannelTypeError,
     InvalidDateTimeFormatError,
     PinPermissionError,
     ThreadCreationError,
 )
-from offkai_bot.util import JST
+from offkai_bot.util import JST, MAX_EVENT_NAME_LENGTH
 
 # pytest marker for async tests
 pytestmark = pytest.mark.asyncio
@@ -513,6 +514,31 @@ async def test_create_offkai_duplicate_event(mock_log, mock_get_event, mock_inte
 
     assert exc_info.value.event_name == event_name
     mock_get_event.assert_called_once_with(event_name)
+    mock_interaction.channel.create_thread.assert_not_awaited()
+
+
+@patch("offkai_bot.cogs.events.get_event")
+@patch("offkai_bot.cogs.events._log")
+async def test_create_offkai_event_name_too_long(mock_log, mock_get_event, mock_interaction, mock_cog):
+    """Test create_offkai rejects names too long for Discord thread names / modal custom_ids."""
+    # Arrange
+    event_name = "a" * (MAX_EVENT_NAME_LENGTH + 1)
+
+    # Act & Assert
+    with pytest.raises(EventNameTooLongError) as exc_info:
+        await EventsCog.create_offkai.callback(
+            mock_cog,
+            mock_interaction,
+            event_name=event_name,
+            venue="Any",
+            address="Any",
+            google_maps_link="Any",
+            date_time="3000-01-01 10:00",
+        )
+
+    assert exc_info.value.event_name == event_name
+    # Validation fails before the duplicate check or any Discord calls
+    mock_get_event.assert_not_called()
     mock_interaction.channel.create_thread.assert_not_awaited()
 
 

--- a/bot/tests/test_interactions.py
+++ b/bot/tests/test_interactions.py
@@ -1,0 +1,50 @@
+"""Tests for interactions.py: GatheringModal construction."""
+
+from datetime import UTC, datetime, timedelta
+
+import pytest
+from offkai_bot.data.event import Event
+from offkai_bot.interactions import MODAL_TITLE_MAX_LENGTH, GatheringModal
+from offkai_bot.util import MAX_EVENT_NAME_LENGTH
+
+pytestmark = pytest.mark.asyncio
+
+
+def _make_event(event_name: str) -> Event:
+    now = datetime.now(UTC)
+    return Event(
+        event_name=event_name,
+        venue="Test Venue",
+        address="123 Test St",
+        google_maps_link="https://maps.google.com/test",
+        event_datetime=now + timedelta(days=30),
+        event_deadline=now + timedelta(days=7),
+        channel_id=456,
+        thread_id=789,
+        message_id=None,
+        open=True,
+        archived=False,
+        drinks=[],
+        max_capacity=None,
+    )
+
+
+async def test_gathering_modal_title_truncated_for_long_event_name():
+    """An event name valid for the custom_id (<= MAX_EVENT_NAME_LENGTH) can still exceed
+    Discord's 45-character modal title limit; the modal must truncate the title rather
+    than pass the raw name through, or sending the modal fails."""
+    event_name = "a" * MAX_EVENT_NAME_LENGTH
+    assert len(event_name) > MODAL_TITLE_MAX_LENGTH  # sanity check for the scenario under test
+
+    modal = GatheringModal(event=_make_event(event_name))
+
+    assert len(modal.title) <= MODAL_TITLE_MAX_LENGTH
+    assert modal.custom_id == f"modal_{event_name}"
+
+
+async def test_gathering_modal_title_unchanged_for_short_event_name():
+    event_name = "Short Event"
+
+    modal = GatheringModal(event=_make_event(event_name))
+
+    assert modal.title == event_name

--- a/bot/tests/test_util.py
+++ b/bot/tests/test_util.py
@@ -12,6 +12,7 @@ from offkai_bot.errors import (
     EventDateTimeInPastError,
     EventDeadlineAfterEventError,
     EventDeadlineInPastError,
+    EventNameTooLongError,
     InvalidChannelTypeError,
     InvalidDateTimeFormatError,
 )
@@ -20,6 +21,7 @@ from offkai_bot.errors import (
 # Import build_checkin_url / build_checkin_token for their own test sections below
 from offkai_bot.util import (
     JST,
+    MAX_EVENT_NAME_LENGTH,
     build_checkin_token,
     build_checkin_url,
     generate_checkin_signature,
@@ -27,6 +29,7 @@ from offkai_bot.util import (
     parse_event_datetime,
     validate_event_datetime,
     validate_event_deadline,
+    validate_event_name,
     validate_interaction_context,
 )
 
@@ -140,6 +143,33 @@ def test_parse_event_datetime_invalid_values():
 def test_parse_drinks(input_str, expected_list):
     """Test parsing various drink strings."""
     assert parse_drinks(input_str) == expected_list
+
+
+# --- Tests for validate_event_name ---
+
+
+def test_validate_event_name_within_limit():
+    """Test that a normal-length event name passes validation."""
+    validate_event_name("Summer Offkai 2026")  # Should not raise
+
+
+def test_validate_event_name_at_limit():
+    """Test that a name exactly at the maximum length passes validation."""
+    validate_event_name("a" * MAX_EVENT_NAME_LENGTH)  # Should not raise
+
+
+def test_validate_event_name_too_long():
+    """Test that a name over the maximum length raises EventNameTooLongError."""
+    long_name = "a" * (MAX_EVENT_NAME_LENGTH + 1)
+    with pytest.raises(EventNameTooLongError) as exc_info:
+        validate_event_name(long_name)
+    assert exc_info.value.event_name == long_name
+    assert exc_info.value.max_length == MAX_EVENT_NAME_LENGTH
+
+
+def test_validate_event_name_limit_fits_discord_custom_id():
+    """The modal custom_id 'modal_<event_name>' must fit Discord's 100-char cap."""
+    assert len("modal_") + MAX_EVENT_NAME_LENGTH <= 100
 
 
 # --- Tests for validate_interaction_context ---


### PR DESCRIPTION
## Summary

Fixes #109.

Discord caps both thread names and modal `custom_id`s at 100 characters, but `event_name` came straight from the `/create_offkai` string option with no length validation:

- Names over 100 chars made `create_thread` fail with a generic HTTP 400.
- Names in the ~94–100 char range were worse: the thread was created fine, but every later "Confirm Attendance" click failed when constructing the `GatheringModal` with the over-long `modal_<event_name>` custom_id — so nobody could register.

## Changes

- **`errors.py`**: new `EventNameTooLongError(BotCommandError)` with a clear message to the organizer (actual length + allowed maximum).
- **`util.py`**: `MAX_EVENT_NAME_LENGTH = 90` and `validate_event_name()` alongside the other validators. 90 = 100-char Discord cap minus the 6-char `modal_` prefix, with a little headroom, as suggested in the issue.
- **`cogs/events.py`**: `create_offkai` calls `validate_event_name()` at the top of business-logic validation, before the duplicate check and any Discord API calls. `/modify_offkai` cannot rename events, so no change needed there.

## Tests

- `test_util.py`: at-limit passes, over-limit raises, plus a guard asserting `len("modal_") + MAX_EVENT_NAME_LENGTH <= 100` so the constant can't drift past the Discord cap.
- `test_create_offkai.py`: command rejects an over-long name before `get_event` or `create_thread` are touched.
- Full suite: 537 passed; `ruff` and `ty` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)