### PR TITLE
Use timezone-aware UTC fallback for unparseable response timestamps

### DIFF
--- a/bot/src/offkai_bot/data/response.py
+++ b/bot/src/offkai_bot/data/response.py
@@ -4,7 +4,7 @@ import logging
 import os
 from collections import Counter
 from dataclasses import dataclass, field
-from datetime import datetime
+from datetime import UTC, datetime
 from typing import TypedDict
 
 # Use relative imports for sibling modules within the package
@@ -222,7 +222,7 @@ def _parse_response_from_dict(resp_dict: dict, event_name: str) -> Response | No
             behavior_confirmed=behavior_confirmed,
             arrival_confirmed=arrival_confirmed,
             event_name=resp_dict.get("event_name", event_name),
-            timestamp=(ts if ts is not None else datetime.now()),
+            timestamp=(ts if ts is not None else datetime.now(UTC)),
             drinks=drinks,
             extras_names=extras_names,
             display_name=display_name,
@@ -266,7 +266,7 @@ def _parse_waitlist_entry_from_dict(entry_dict: dict, event_name: str) -> Waitli
             behavior_confirmed=behavior_confirmed,
             arrival_confirmed=arrival_confirmed,
             event_name=entry_dict.get("event_name", event_name),
-            timestamp=(ts if ts is not None else datetime.now()),
+            timestamp=(ts if ts is not None else datetime.now(UTC)),
             drinks=drinks,
             extras_names=extras_names,
             display_name=display_name,

--- a/bot/tests/data/test_response.py
+++ b/bot/tests/data/test_response.py
@@ -346,6 +346,21 @@ def test_load_responses_invalid_timestamp(mock_datetime, mock_paths):
         assert "Could not parse ISO timestamp" in str(mock_log.warning.call_args)
 
 
+def test_parse_fallback_timestamp_is_aware_utc():
+    """Fallback timestamp for unparseable input must be timezone-aware UTC, not naive local time."""
+    invalid_ts_resp = RESP_1_DICT.copy()
+    invalid_ts_resp["timestamp"] = "invalid-ts"
+
+    with patch("offkai_bot.data.response._log"):
+        response = response_data._parse_response_from_dict(invalid_ts_resp, "Event A")
+        entry = response_data._parse_waitlist_entry_from_dict(invalid_ts_resp, "Event A")
+
+    assert response is not None
+    assert response.timestamp.tzinfo is UTC
+    assert entry is not None
+    assert entry.timestamp.tzinfo is UTC
+
+
 def test_load_responses_invalid_numeric_field(mock_paths):
     """Test loading data with non-numeric extra_people."""
     bad_resp_dict = RESP_1_DICT.copy()


### PR DESCRIPTION
## Summary

Fixes #110.

The timestamp parse fallbacks in `_parse_response_from_dict` and `_parse_waitlist_entry_from_dict` (`bot/src/offkai_bot/data/response.py`) used naive `datetime.now()`, while every timestamp written by the bot is timezone-aware UTC (`datetime.now(UTC)`). A single unparseable stored timestamp would:

- make any comparison/sort of response timestamps raise `TypeError: can't compare offset-naive and offset-aware datetimes`, and
- serialize back an offset-less value that is ambiguous (and wrong by the server's UTC offset) on the next load.

Both fallbacks now use `datetime.now(UTC)`, matching the project convention.

## Testing

- Added `test_parse_fallback_timestamp_is_aware_utc`, which feeds an unparseable timestamp to both parsers and asserts the fallback timestamp has `tzinfo is UTC`. The existing invalid-timestamp test mocks `datetime` entirely, so it could not catch naive vs. aware.
- `uv run pytest bot/tests` — 533 passed.
- `uvx ruff check` and `uvx ty check` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)