### PR TITLE
Minor hardening: context validation, guarded error responses, drop unused intent

### DIFF
--- a/bot/src/offkai_bot/cogs/events.py
+++ b/bot/src/offkai_bot/cogs/events.py
@@ -381,6 +381,7 @@ class EventsCog(commands.Cog):
     @app_commands.checks.has_role("Offkai Organizer")
     @log_command_usage
     async def close_offkai(self, interaction: discord.Interaction, event_name: str, close_msg: str | None = None):
+        validate_interaction_context(interaction)
         await interaction.response.defer()
         try:
             await perform_close_event(self.bot, event_name, close_msg)
@@ -400,6 +401,7 @@ class EventsCog(commands.Cog):
     @app_commands.checks.has_role("Offkai Organizer")
     @log_command_usage
     async def reopen_offkai(self, interaction: discord.Interaction, event_name: str, reopen_msg: str | None = None):
+        validate_interaction_context(interaction)
         await interaction.response.defer()
         reopened_event = set_event_open_status(event_name, target_open_status=True)
         clear_attendee_numbers(event_name)
@@ -437,6 +439,7 @@ class EventsCog(commands.Cog):
     @app_commands.checks.has_role("Offkai Organizer")
     @log_command_usage
     async def archive_offkai(self, interaction: discord.Interaction, event_name: str):
+        validate_interaction_context(interaction)
         await interaction.response.defer()
         archived_event = archive_event(event_name)
         save_event_data()
@@ -480,6 +483,7 @@ class EventsCog(commands.Cog):
     @app_commands.checks.has_role("Offkai Organizer")
     @log_command_usage
     async def broadcast(self, interaction: discord.Interaction, event_name: str, message: str):
+        validate_interaction_context(interaction)
         await interaction.response.defer(ephemeral=True)
         event = get_event(event_name)
         thread = await fetch_thread_for_event(self.bot, event)
@@ -500,6 +504,7 @@ class EventsCog(commands.Cog):
     @app_commands.checks.has_role("Offkai Organizer")
     @log_command_usage
     async def delete_response(self, interaction: discord.Interaction, event_name: str, member: discord.Member):
+        validate_interaction_context(interaction)
         await interaction.response.defer(ephemeral=True)
         event = get_event(event_name)
         remove_response(event_name, member.id)
@@ -536,6 +541,7 @@ class EventsCog(commands.Cog):
     @app_commands.checks.has_role("Offkai Organizer")
     @log_command_usage
     async def promote(self, interaction: discord.Interaction, event_name: str, username: str):
+        validate_interaction_context(interaction)
         await interaction.response.defer(ephemeral=True)
         event = get_event(event_name)
 
@@ -611,6 +617,7 @@ class EventsCog(commands.Cog):
         nicknames: bool = False,
         drinks: bool = False,
     ):
+        validate_interaction_context(interaction)
         await interaction.response.defer(ephemeral=True)
         get_event(event_name)
         total_count, attendee_list = calculate_attendance(event_name, nicknames=nicknames, drinks=drinks, sort=sort)
@@ -651,6 +658,7 @@ class EventsCog(commands.Cog):
     @app_commands.checks.has_role("Offkai Organizer")
     @log_command_usage
     async def attendance_report(self, interaction: discord.Interaction, event_name: str):
+        validate_interaction_context(interaction)
         await interaction.response.defer(ephemeral=True)
         event = get_event(event_name)
         if event.open or not has_complete_attendee_numbers(event_name):
@@ -697,6 +705,7 @@ class EventsCog(commands.Cog):
     async def waitlist(
         self, interaction: discord.Interaction, event_name: str, sort: bool = False, nicknames: bool = False
     ):
+        validate_interaction_context(interaction)
         get_event(event_name)
         total_count, waitlisted_list = calculate_waitlist(event_name, nicknames=nicknames, sort=sort)
 
@@ -718,6 +727,7 @@ class EventsCog(commands.Cog):
     @app_commands.checks.has_role("Offkai Organizer")
     @log_command_usage
     async def drinks(self, interaction: discord.Interaction, event_name: str):
+        validate_interaction_context(interaction)
         get_event(event_name)
         total_count, drinks_count = calculate_drinks(event_name)
 

--- a/bot/src/offkai_bot/cogs/events.py
+++ b/bot/src/offkai_bot/cogs/events.py
@@ -64,6 +64,7 @@ from offkai_bot.util import (
     parse_event_datetime,
     validate_event_datetime,
     validate_event_deadline,
+    validate_guild_context,
     validate_interaction_context,
 )
 
@@ -381,7 +382,7 @@ class EventsCog(commands.Cog):
     @app_commands.checks.has_role("Offkai Organizer")
     @log_command_usage
     async def close_offkai(self, interaction: discord.Interaction, event_name: str, close_msg: str | None = None):
-        validate_interaction_context(interaction)
+        validate_guild_context(interaction)
         await interaction.response.defer()
         try:
             await perform_close_event(self.bot, event_name, close_msg)
@@ -401,7 +402,7 @@ class EventsCog(commands.Cog):
     @app_commands.checks.has_role("Offkai Organizer")
     @log_command_usage
     async def reopen_offkai(self, interaction: discord.Interaction, event_name: str, reopen_msg: str | None = None):
-        validate_interaction_context(interaction)
+        validate_guild_context(interaction)
         await interaction.response.defer()
         reopened_event = set_event_open_status(event_name, target_open_status=True)
         clear_attendee_numbers(event_name)
@@ -439,7 +440,7 @@ class EventsCog(commands.Cog):
     @app_commands.checks.has_role("Offkai Organizer")
     @log_command_usage
     async def archive_offkai(self, interaction: discord.Interaction, event_name: str):
-        validate_interaction_context(interaction)
+        validate_guild_context(interaction)
         await interaction.response.defer()
         archived_event = archive_event(event_name)
         save_event_data()
@@ -483,7 +484,7 @@ class EventsCog(commands.Cog):
     @app_commands.checks.has_role("Offkai Organizer")
     @log_command_usage
     async def broadcast(self, interaction: discord.Interaction, event_name: str, message: str):
-        validate_interaction_context(interaction)
+        validate_guild_context(interaction)
         await interaction.response.defer(ephemeral=True)
         event = get_event(event_name)
         thread = await fetch_thread_for_event(self.bot, event)
@@ -504,7 +505,7 @@ class EventsCog(commands.Cog):
     @app_commands.checks.has_role("Offkai Organizer")
     @log_command_usage
     async def delete_response(self, interaction: discord.Interaction, event_name: str, member: discord.Member):
-        validate_interaction_context(interaction)
+        validate_guild_context(interaction)
         await interaction.response.defer(ephemeral=True)
         event = get_event(event_name)
         remove_response(event_name, member.id)
@@ -541,7 +542,7 @@ class EventsCog(commands.Cog):
     @app_commands.checks.has_role("Offkai Organizer")
     @log_command_usage
     async def promote(self, interaction: discord.Interaction, event_name: str, username: str):
-        validate_interaction_context(interaction)
+        validate_guild_context(interaction)
         await interaction.response.defer(ephemeral=True)
         event = get_event(event_name)
 
@@ -617,7 +618,7 @@ class EventsCog(commands.Cog):
         nicknames: bool = False,
         drinks: bool = False,
     ):
-        validate_interaction_context(interaction)
+        validate_guild_context(interaction)
         await interaction.response.defer(ephemeral=True)
         get_event(event_name)
         total_count, attendee_list = calculate_attendance(event_name, nicknames=nicknames, drinks=drinks, sort=sort)
@@ -658,7 +659,7 @@ class EventsCog(commands.Cog):
     @app_commands.checks.has_role("Offkai Organizer")
     @log_command_usage
     async def attendance_report(self, interaction: discord.Interaction, event_name: str):
-        validate_interaction_context(interaction)
+        validate_guild_context(interaction)
         await interaction.response.defer(ephemeral=True)
         event = get_event(event_name)
         if event.open or not has_complete_attendee_numbers(event_name):
@@ -705,7 +706,7 @@ class EventsCog(commands.Cog):
     async def waitlist(
         self, interaction: discord.Interaction, event_name: str, sort: bool = False, nicknames: bool = False
     ):
-        validate_interaction_context(interaction)
+        validate_guild_context(interaction)
         get_event(event_name)
         total_count, waitlisted_list = calculate_waitlist(event_name, nicknames=nicknames, sort=sort)
 
@@ -727,7 +728,7 @@ class EventsCog(commands.Cog):
     @app_commands.checks.has_role("Offkai Organizer")
     @log_command_usage
     async def drinks(self, interaction: discord.Interaction, event_name: str):
-        validate_interaction_context(interaction)
+        validate_guild_context(interaction)
         get_event(event_name)
         total_count, drinks_count = calculate_drinks(event_name)
 

--- a/bot/src/offkai_bot/main.py
+++ b/bot/src/offkai_bot/main.py
@@ -99,12 +99,29 @@ class OffkaiClient(commands.Bot):
 
 
 intents = discord.Intents.default()
-intents.message_content = True
 
 client = OffkaiClient(intents=intents)
 
 
 # --- Error Handler ---
+
+
+async def _send_error_message(interaction: discord.Interaction, message: str, user_info: str) -> None:
+    """Sends an ephemeral error message, falling back to a followup if the interaction was already acknowledged."""
+    try:
+        if not interaction.response.is_done():
+            await interaction.response.send_message(message, ephemeral=True)
+        else:
+            await interaction.followup.send(message, ephemeral=True)
+    except discord.HTTPException as http_err:
+        _log.error("%s - Failed to send error response message: %s", user_info, http_err)
+    except Exception as e:
+        _log.error(
+            "%s - Exception sending error response message: %s",
+            user_info,
+            e,
+            exc_info=e,
+        )
 
 
 @client.tree.error
@@ -118,13 +135,13 @@ async def on_command_error(interaction: discord.Interaction, error: app_commands
         case app_commands.MissingRole():
             message = "❌ You need the Offkai Organizer role to use this command."
             _log.warning("%s - Missing Offkai Organizer role for command '%s'.", user_info, command_name)
-            await interaction.response.send_message(message, ephemeral=True)
+            await _send_error_message(interaction, message, user_info)
             return  # Handled
 
         case app_commands.CheckFailure():
             message = "❌ You do not have permission to use this command."
             _log.warning("%s - CheckFailure for command '%s'.", user_info, command_name)
-            await interaction.response.send_message(message, ephemeral=True)
+            await _send_error_message(interaction, message, user_info)
             return  # Handled
 
     # For other errors, work with the 'original' error if it exists
@@ -167,20 +184,7 @@ async def on_command_error(interaction: discord.Interaction, error: app_commands
 
     # Send the response (if a message was set)
     if message:
-        try:
-            if not interaction.response.is_done():
-                await interaction.response.send_message(message, ephemeral=True)
-            else:
-                await interaction.followup.send(message, ephemeral=True)
-        except discord.HTTPException as http_err:
-            _log.error("%s - Failed to send error response message: %s", user_info, http_err)
-        except Exception as e:
-            _log.error(
-                "%s - Exception sending error response message: %s",
-                user_info,
-                e,
-                exc_info=e,
-            )
+        await _send_error_message(interaction, message, user_info)
 
 
 # Event to run when the client is ready

--- a/bot/src/offkai_bot/main.py
+++ b/bot/src/offkai_bot/main.py
@@ -156,8 +156,8 @@ async def on_command_error(interaction: discord.Interaction, error: app_commands
         case PinPermissionError() as e:
             log_level = getattr(e, "log_level", logging.WARNING)
             _log.log(log_level, "%s - Handled (%s): %s", user_info, type(e).__name__, e)
-            # The initial response was already sent by the command, so we use a followup
-            await interaction.followup.send(str(e), ephemeral=True)
+            # The initial response was already sent by the command, so this lands on the followup path
+            await _send_error_message(interaction, str(e), user_info)
             return  # Handled
 
         # --- Unified Case for other custom errors ---

--- a/bot/src/offkai_bot/util.py
+++ b/bot/src/offkai_bot/util.py
@@ -71,6 +71,17 @@ def validate_interaction_context(interaction: discord.Interaction):
         raise InvalidChannelTypeError()
 
 
+def validate_guild_context(interaction: discord.Interaction):
+    """Checks if the command is used in a guild text channel or thread.
+
+    For commands that operate on stored event data (or only produce reports) and thus
+    don't need the current channel to be the parent text channel — e.g. organizers
+    running them from inside an event thread.
+    """
+    if not interaction.guild or not isinstance(interaction.channel, discord.TextChannel | discord.Thread):
+        raise InvalidChannelTypeError(expected_type="server text channel or thread")
+
+
 # --- NEW DATETIME VALIDATION FUNCTIONS ---
 
 

--- a/bot/tests/commands/test_close_offkai.py
+++ b/bot/tests/commands/test_close_offkai.py
@@ -37,6 +37,9 @@ def mock_interaction():
     interaction.guild = MagicMock(spec=discord.Guild)
     interaction.guild.id = 789
 
+    interaction.channel = MagicMock(spec=discord.TextChannel)
+    interaction.channel.id = 456
+
     interaction.command = MagicMock(spec=app_commands.Command)
     interaction.command.name = "close_offkai"
 

--- a/bot/tests/commands/test_context_validation.py
+++ b/bot/tests/commands/test_context_validation.py
@@ -7,7 +7,7 @@ import pytest
 from discord import app_commands
 from discord.ext import commands
 from offkai_bot.cogs.events import EventsCog
-from offkai_bot.errors import InvalidChannelTypeError
+from offkai_bot.errors import EventNotFoundError, InvalidChannelTypeError
 
 # pytest marker for async tests
 pytestmark = pytest.mark.asyncio
@@ -48,6 +48,8 @@ def mock_interaction():
 
 
 # Each command with the extra kwargs (beyond event_name) needed to invoke it.
+# These commands operate on stored event data (or only produce reports), so they
+# accept both guild text channels and guild threads.
 COMMANDS_REQUIRING_CONTEXT = [
     ("close_offkai", {}),
     ("reopen_offkai", {}),
@@ -91,6 +93,59 @@ async def test_command_rejects_missing_guild(mock_cog, mock_interaction, command
     # Act / Assert
     with pytest.raises(InvalidChannelTypeError):
         await command.callback(mock_cog, mock_interaction, event_name="Summer Bash", **extra_kwargs)
+
+    mock_interaction.response.defer.assert_not_called()
+    mock_interaction.response.send_message.assert_not_called()
+
+
+@pytest.mark.parametrize("command_name, extra_kwargs", COMMANDS_REQUIRING_CONTEXT)
+async def test_command_allows_guild_thread(mock_cog, mock_interaction, command_name, extra_kwargs):
+    """Event-management/report commands should pass context validation when run from a guild thread.
+
+    The event cache is empty, so getting past the channel check surfaces as
+    EventNotFoundError — raising InvalidChannelTypeError instead would mean the
+    thread context was wrongly rejected.
+    """
+    # Arrange
+    mock_interaction.channel = MagicMock(spec=discord.Thread)
+    command = getattr(EventsCog, command_name)
+
+    # Act / Assert
+    with pytest.raises(EventNotFoundError):
+        await command.callback(mock_cog, mock_interaction, event_name="Summer Bash", **extra_kwargs)
+
+
+async def test_modify_offkai_rejects_guild_thread(mock_cog, mock_interaction):
+    """Commands that need the current channel as the event's parent stay strict: threads are rejected."""
+    # Arrange
+    mock_interaction.channel = MagicMock(spec=discord.Thread)
+
+    # Act / Assert
+    with pytest.raises(InvalidChannelTypeError):
+        await EventsCog.modify_offkai.callback(
+            mock_cog, mock_interaction, event_name="Summer Bash", update_msg="Update!"
+        )
+
+    mock_interaction.response.defer.assert_not_called()
+    mock_interaction.response.send_message.assert_not_called()
+
+
+async def test_create_offkai_rejects_guild_thread(mock_cog, mock_interaction):
+    """create_offkai creates the event thread from the current channel, so a thread context is rejected."""
+    # Arrange
+    mock_interaction.channel = MagicMock(spec=discord.Thread)
+
+    # Act / Assert
+    with pytest.raises(InvalidChannelTypeError):
+        await EventsCog.create_offkai.callback(
+            mock_cog,
+            mock_interaction,
+            event_name="Summer Bash",
+            venue="Venue",
+            address="Address",
+            google_maps_link="https://maps.example.com",
+            date_time="3024-08-15 19:30",
+        )
 
     mock_interaction.response.defer.assert_not_called()
     mock_interaction.response.send_message.assert_not_called()

--- a/bot/tests/commands/test_context_validation.py
+++ b/bot/tests/commands/test_context_validation.py
@@ -1,0 +1,96 @@
+# tests/commands/test_context_validation.py
+
+from unittest.mock import AsyncMock, MagicMock
+
+import discord
+import pytest
+from discord import app_commands
+from discord.ext import commands
+from offkai_bot.cogs.events import EventsCog
+from offkai_bot.errors import InvalidChannelTypeError
+
+# pytest marker for async tests
+pytestmark = pytest.mark.asyncio
+
+# --- Fixtures ---
+
+
+@pytest.fixture
+def mock_cog():
+    """Fixture to create a mock EventsCog instance."""
+    bot = MagicMock(spec=commands.Bot)
+    return EventsCog(bot)
+
+
+@pytest.fixture
+def mock_interaction():
+    """Fixture to create a mock discord.Interaction with necessary attributes."""
+    interaction = MagicMock(spec=discord.Interaction)
+    interaction.user = MagicMock(spec=discord.Member)
+    interaction.user.id = 123
+    interaction.user.__str__.return_value = "TestUser#1234"
+
+    interaction.guild = MagicMock(spec=discord.Guild)
+    interaction.guild.id = 789
+
+    interaction.channel = MagicMock(spec=discord.TextChannel)
+    interaction.channel.id = 456
+
+    interaction.command = MagicMock(spec=app_commands.Command)
+    interaction.command.name = "mock_command"
+
+    interaction.response = MagicMock()
+    interaction.response.send_message = AsyncMock()
+    interaction.response.defer = AsyncMock()
+    interaction.followup = MagicMock(send=AsyncMock())
+
+    return interaction
+
+
+# Each command with the extra kwargs (beyond event_name) needed to invoke it.
+COMMANDS_REQUIRING_CONTEXT = [
+    ("close_offkai", {}),
+    ("reopen_offkai", {}),
+    ("archive_offkai", {}),
+    ("broadcast", {"message": "Hello"}),
+    ("delete_response", {"member": MagicMock(spec=discord.Member)}),
+    ("promote", {"username": "123"}),
+    ("attendance", {}),
+    ("attendance_report", {}),
+    ("waitlist", {}),
+    ("drinks", {}),
+]
+
+
+# --- Test Cases ---
+
+
+@pytest.mark.parametrize("command_name, extra_kwargs", COMMANDS_REQUIRING_CONTEXT)
+async def test_command_rejects_non_text_channel(mock_cog, mock_interaction, command_name, extra_kwargs):
+    """Commands should raise InvalidChannelTypeError before doing any work when not in a guild text channel."""
+    # Arrange
+    mock_interaction.channel = MagicMock(spec=discord.DMChannel)
+    command = getattr(EventsCog, command_name)
+
+    # Act / Assert
+    with pytest.raises(InvalidChannelTypeError):
+        await command.callback(mock_cog, mock_interaction, event_name="Summer Bash", **extra_kwargs)
+
+    # The interaction must not have been acknowledged before validation failed
+    mock_interaction.response.defer.assert_not_called()
+    mock_interaction.response.send_message.assert_not_called()
+
+
+@pytest.mark.parametrize("command_name, extra_kwargs", COMMANDS_REQUIRING_CONTEXT)
+async def test_command_rejects_missing_guild(mock_cog, mock_interaction, command_name, extra_kwargs):
+    """Commands should raise InvalidChannelTypeError when invoked outside a guild."""
+    # Arrange
+    mock_interaction.guild = None
+    command = getattr(EventsCog, command_name)
+
+    # Act / Assert
+    with pytest.raises(InvalidChannelTypeError):
+        await command.callback(mock_cog, mock_interaction, event_name="Summer Bash", **extra_kwargs)
+
+    mock_interaction.response.defer.assert_not_called()
+    mock_interaction.response.send_message.assert_not_called()

--- a/bot/tests/test_error_handling.py
+++ b/bot/tests/test_error_handling.py
@@ -111,6 +111,59 @@ async def test_on_command_error_check_failure(mock_interaction):
         assert "User: TestUser#1234 (1234567890)" in log_message
 
 
+async def test_on_command_error_missing_role_interaction_done(mock_interaction):
+    """Test MissingRole handling when the interaction was already acknowledged."""
+    # Arrange
+    error = app_commands.MissingRole("Offkai Organizer")
+    mock_interaction.response.is_done.return_value = True
+
+    with patch("offkai_bot.main._log"):
+        # Act
+        await main.on_command_error(mock_interaction, error)
+
+        # Assert: Uses followup instead of the initial response
+        expected_message = "❌ You need the Offkai Organizer role to use this command."
+        mock_interaction.followup.send.assert_awaited_once_with(expected_message, ephemeral=True)
+        mock_interaction.response.send_message.assert_not_called()
+
+
+async def test_on_command_error_check_failure_interaction_done(mock_interaction):
+    """Test CheckFailure handling when the interaction was already acknowledged."""
+    # Arrange
+    error = app_commands.CheckFailure("Some check failed")
+    mock_interaction.response.is_done.return_value = True
+
+    with patch("offkai_bot.main._log"):
+        # Act
+        await main.on_command_error(mock_interaction, error)
+
+        # Assert: Uses followup instead of the initial response
+        expected_message = "❌ You do not have permission to use this command."
+        mock_interaction.followup.send.assert_awaited_once_with(expected_message, ephemeral=True)
+        mock_interaction.response.send_message.assert_not_called()
+
+
+async def test_on_command_error_check_failure_send_fails(mock_interaction):
+    """Test that a failure sending the CheckFailure response is logged, not raised."""
+    # Arrange
+    error = app_commands.CheckFailure("Some check failed")
+    send_error = discord.HTTPException(MagicMock(), "Failed to send")
+    mock_interaction.response.send_message.side_effect = send_error
+
+    with patch("offkai_bot.main._log") as mock_log:
+        # Act (must not raise)
+        await main.on_command_error(mock_interaction, error)
+
+        # Assert: The send failure was logged
+        mock_log.error.assert_called_once()
+        log_call_args = mock_log.error.call_args[0]
+        log_error_msg = log_call_args[0] % log_call_args[1:]
+        assert "Failed to send error response message" in log_error_msg
+
+        # Assert: No followup attempted after the response failed
+        mock_interaction.followup.send.assert_not_called()
+
+
 # --- Parametrized Test for Custom BotCommandErrors ---
 @pytest.mark.parametrize(
     "error_class, error_args, expected_log_level, expected_log_level_name_in_msg",

--- a/bot/tests/test_error_handling.py
+++ b/bot/tests/test_error_handling.py
@@ -372,6 +372,56 @@ async def test_on_command_error_fails_sending_response(mock_interaction):
         mock_interaction.followup.send.assert_not_called()
 
 
+async def test_on_command_error_pin_permission_error(mock_interaction):
+    """Test PinPermissionError is sent via the guarded helper (followup, since the command already responded)."""
+    # Arrange
+    original_error = errors.PinPermissionError(
+        MagicMock(spec=discord.Thread, mention="<#123>"),
+        MagicMock(spec=discord.Forbidden),
+    )
+    error = app_commands.CommandInvokeError(mock_interaction.command, original_error)
+    # The command already sent its initial response before the pin failed
+    mock_interaction.response.is_done.return_value = True
+
+    with patch("offkai_bot.main._log") as mock_log:
+        # Act
+        await main.on_command_error(mock_interaction, error)
+
+        # Assert: Sent as a followup, not the initial response
+        mock_interaction.followup.send.assert_awaited_once_with(str(original_error), ephemeral=True)
+        mock_interaction.response.send_message.assert_not_called()
+
+        # Assert: Logged as handled at WARNING level
+        mock_log.log.assert_called_once()
+        call_args, _ = mock_log.log.call_args
+        assert call_args[0] == logging.WARNING
+        log_message = call_args[1] % call_args[2:]
+        assert "Handled (PinPermissionError)" in log_message
+
+
+async def test_on_command_error_pin_permission_error_send_fails(mock_interaction):
+    """Test that a failure sending the PinPermissionError followup is logged, not raised."""
+    # Arrange
+    original_error = errors.PinPermissionError(
+        MagicMock(spec=discord.Thread, mention="<#123>"),
+        MagicMock(spec=discord.Forbidden),
+    )
+    error = app_commands.CommandInvokeError(mock_interaction.command, original_error)
+    mock_interaction.response.is_done.return_value = True
+    send_error = discord.HTTPException(MagicMock(), "Failed to send")
+    mock_interaction.followup.send.side_effect = send_error
+
+    with patch("offkai_bot.main._log") as mock_log:
+        # Act (must not raise)
+        await main.on_command_error(mock_interaction, error)
+
+        # Assert: The send failure was logged
+        mock_log.error.assert_called_once()
+        log_call_args = mock_log.error.call_args[0]
+        log_error_msg = log_call_args[0] % log_call_args[1:]
+        assert "Failed to send error response message" in log_error_msg
+
+
 async def test_on_command_error_no_command_context(mock_interaction):
     """Test error handling when interaction.command is None."""
     # Arrange

--- a/bot/tests/test_util.py
+++ b/bot/tests/test_util.py
@@ -27,6 +27,7 @@ from offkai_bot.util import (
     parse_event_datetime,
     validate_event_datetime,
     validate_event_deadline,
+    validate_guild_context,
     validate_interaction_context,
 )
 
@@ -191,6 +192,47 @@ def test_validate_interaction_context_wrong_channel_type(mock_interaction, chann
 
     with pytest.raises(InvalidChannelTypeError):
         validate_interaction_context(mock_interaction)
+
+
+# --- Tests for validate_guild_context ---
+
+
+@pytest.mark.parametrize("channel_type", [discord.TextChannel, discord.Thread])
+def test_validate_guild_context_success(mock_interaction, channel_type):
+    """Test validation succeeds in a guild text channel or guild thread."""
+    mock_interaction.guild = MagicMock(spec=discord.Guild)
+    mock_interaction.channel = MagicMock(spec=channel_type)
+    # Should not raise any error
+    try:
+        validate_guild_context(mock_interaction)
+    except InvalidChannelTypeError:
+        pytest.fail("validate_guild_context raised InvalidChannelTypeError unexpectedly")
+
+
+def test_validate_guild_context_no_guild(mock_interaction):
+    """Test validation fails when interaction.guild is None (DM), even with a thread channel."""
+    mock_interaction.guild = None
+    mock_interaction.channel = MagicMock(spec=discord.Thread)
+    with pytest.raises(InvalidChannelTypeError):
+        validate_guild_context(mock_interaction)
+
+
+@pytest.mark.parametrize(
+    "channel_type",
+    [
+        discord.DMChannel,
+        discord.VoiceChannel,
+        discord.CategoryChannel,
+        None,  # Test None channel explicitly
+    ],
+)
+def test_validate_guild_context_wrong_channel_type(mock_interaction, channel_type):
+    """Test validation fails with channel types that are neither TextChannel nor Thread."""
+    mock_interaction.guild = MagicMock(spec=discord.Guild)
+    mock_interaction.channel = MagicMock(spec=channel_type) if channel_type else None
+
+    with pytest.raises(InvalidChannelTypeError):
+        validate_guild_context(mock_interaction)
 
 
 # --- NEW Tests for validate_event_datetime ---


### PR DESCRIPTION
Fixes #111.

## Changes

**1. Context validation on all commands, split by need** (`bot/src/offkai_bot/cogs/events.py`, `bot/src/offkai_bot/util.py`)

Validation is added as the first call in `close_offkai`, `reopen_offkai`, `archive_offkai`, `broadcast`, `delete_response`, `promote`, `attendance`, `attendance_report`, `waitlist`, and `drinks`. The issue listed nine commands; `attendance_report` is included as well since CLAUDE.md says every command should call it.

Per review feedback, validation is split by what each command actually needs:

- **`validate_guild_context()`** (new) — accepts guild text channels **and guild threads**. Used by the ten commands above, which operate on stored event/thread data or only produce reports, so organizers can run them from inside an event thread. DMs and other channel types are still rejected.
- **`validate_interaction_context()`** (strict, unchanged) — requires a guild `TextChannel`. Kept for `create_offkai` and `modify_offkai`, which use the current channel as the event's parent.

**2. Guarded error responses** (`bot/src/offkai_bot/main.py`)

The `MissingRole`/`CheckFailure` branches in `on_command_error` previously called `interaction.response.send_message` directly — if the interaction was already acknowledged or expired, the error handler itself raised. The guarded send logic (`is_done()` check → followup fallback, `HTTPException` swallowed and logged) is now extracted into a shared `_send_error_message()` helper used by all branches, **including the `PinPermissionError` branch** (per review feedback), which previously called `interaction.followup.send` directly.

**3. Dropped unused `message_content` intent** (`bot/src/offkai_bot/main.py`)

The bot is slash-command-only, so the privileged intent was unused. The Message Content privileged-intent toggle can also be disabled in the Discord developer portal once this deploys.

## Tests

- `bot/tests/commands/test_context_validation.py`: parametrized over all ten relaxed commands — rejects DMs/non-guild contexts (before the interaction is acknowledged) and **passes validation from a guild thread**; strict tests assert `create_offkai`/`modify_offkai` reject threads.
- `bot/tests/test_util.py`: unit tests for the new `validate_guild_context()`.
- Error-handler tests: `MissingRole`/`CheckFailure` when the interaction is already acknowledged (uses followup), when sending the response itself fails (logged, not raised), and `PinPermissionError` routed through the guarded helper including a failing followup send.
- `test_close_offkai.py` fixture gains a `TextChannel` mock to satisfy the new validation.

All gates pass: `ruff check`, `ruff format`, `ty check`, and `pytest bot/tests` (576 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)