### PR TITLE
fix: allow date-only /modify_offkai when the existing deadline has passed

### DIFF
--- a/bot/src/offkai_bot/data/event.py
+++ b/bot/src/offkai_bot/data/event.py
@@ -475,8 +475,13 @@ def update_event_details(
         # This will raise InvalidDateTimeFormatError immediately if parsing fails
         parsed_datetime = parse_event_datetime(date_time_str)
         validate_event_datetime(parsed_datetime)
-        # If the deadline isn't being changed, the new datetime must still respect the existing one
-        validate_event_deadline(parsed_datetime, parsed_deadline if deadline_str is not None else event.event_deadline)
+        if deadline_str is not None:
+            validate_event_deadline(parsed_datetime, parsed_deadline)
+        else:
+            # The deadline isn't being changed, so the new datetime must still come after
+            # it — but an existing deadline that has already passed shouldn't block the
+            # change (that's normal once signups have closed).
+            validate_event_deadline(parsed_datetime, event.event_deadline, require_future=False)
     else:
         validate_event_deadline(event.event_datetime, parsed_deadline)
 

--- a/bot/src/offkai_bot/util.py
+++ b/bot/src/offkai_bot/util.py
@@ -113,7 +113,7 @@ def validate_event_datetime(event_datetime: datetime):
     _log.debug("Validation success: Event datetime %s is in the future.", event_datetime)
 
 
-def validate_event_deadline(event_datetime: datetime, event_deadline: datetime | None):
+def validate_event_deadline(event_datetime: datetime, event_deadline: datetime | None, *, require_future: bool = True):
     """
     Validates that the event deadline is set in the future (compared to current UTC)
     and occurs before the event datetime. If event deadline is None, then no validation is done.
@@ -121,9 +121,12 @@ def validate_event_deadline(event_datetime: datetime, event_deadline: datetime |
     Args:
         event_datetime: The aware UTC datetime of the event.
         event_deadline: The aware UTC datetime of the deadline. Can be None.
+        require_future: Whether the deadline must be in the future. Pass False when
+            re-validating an existing, unchanged deadline (a legitimately passed
+            deadline should not block other modifications).
 
     Raises:
-        DeadlineInPastError: If the event_deadline is not in the future.
+        DeadlineInPastError: If require_future and the event_deadline is not in the future.
         DeadlineAfterEventError: If the event_deadline is not before the event_datetime.
     """
     if not event_deadline:
@@ -132,7 +135,7 @@ def validate_event_deadline(event_datetime: datetime, event_deadline: datetime |
     now_utc = datetime.now(UTC)
 
     # 1. Check if deadline is in the future
-    if event_deadline < now_utc:
+    if require_future and event_deadline < now_utc:
         _log.info("Validation failed: Deadline %s is in the past compared to %s.", event_deadline, now_utc)
         raise EventDeadlineInPastError()
 

--- a/bot/tests/data/test_event.py
+++ b/bot/tests/data/test_event.py
@@ -1102,6 +1102,32 @@ def test_update_event_details_fails_new_event_time_before_existing_deadline(
     mock_save.assert_not_called()
 
 
+@patch("offkai_bot.data.event.parse_drinks", return_value=[])
+@patch("offkai_bot.data.event.save_event_data")
+@patch("offkai_bot.data.event._log")
+def test_update_event_details_allows_new_event_time_with_past_deadline(mock_log, mock_save, mock_parse_drinks):
+    """Regression test: moving only the event time must succeed even after the
+    existing (unchanged) deadline has legitimately passed."""
+    test_event = copy.deepcopy(BASE_EVENT_OBJ)
+    test_event.event_deadline = PAST_DEADLINE  # Signups already closed
+    new_event_time = TEST_NOW_UTC + timedelta(hours=11)  # Later the same day, still after the deadline
+
+    with (
+        patch("offkai_bot.data.event.get_event", return_value=test_event),
+        patch("offkai_bot.data.event.parse_event_datetime", return_value=new_event_time) as mock_parse_dt,
+    ):
+        # Uses the real validators: the past deadline must not raise EventDeadlineInPastError
+        updated_event = event_data.update_event_details(
+            event_name=test_event.event_name,
+            date_time_str="later-today",
+        )
+
+    assert updated_event.event_datetime == new_event_time
+    assert updated_event.event_deadline == PAST_DEADLINE  # Deadline untouched
+    mock_parse_dt.assert_called_once_with("later-today")
+    mock_save.assert_not_called()
+
+
 @patch("offkai_bot.data.event.get_event", return_value=copy.deepcopy(BASE_EVENT_OBJ))  # max_capacity=None
 @patch("offkai_bot.data.event.get_waitlist", return_value=[])
 @patch("offkai_bot.data.event.get_responses")

--- a/bot/tests/test_util.py
+++ b/bot/tests/test_util.py
@@ -297,6 +297,26 @@ def test_validate_event_deadline_past(mock_dt):
 
     with pytest.raises(EventDeadlineInPastError):
         validate_event_deadline(FUTURE_EVENT_AFTER_DEADLINE, PAST_DEADLINE)
+
+
+@patch("offkai_bot.util.datetime")
+def test_validate_event_deadline_past_allowed_when_not_required_future(mock_dt):
+    """Test a past deadline passes when require_future=False, as long as it precedes the event."""
+    mock_dt.now.return_value = NOW_UTC_FOR_DEADLINE
+
+    try:
+        validate_event_deadline(FUTURE_EVENT_AFTER_DEADLINE, PAST_DEADLINE, require_future=False)
+    except (EventDeadlineInPastError, EventDeadlineAfterEventError):
+        pytest.fail("validate_event_deadline raised an error unexpectedly")
+
+
+@patch("offkai_bot.util.datetime")
+def test_validate_event_deadline_ordering_still_checked_when_not_required_future(mock_dt):
+    """Test require_future=False still rejects a deadline that is not before the event time."""
+    mock_dt.now.return_value = NOW_UTC_FOR_DEADLINE
+
+    with pytest.raises(EventDeadlineAfterEventError):
+        validate_event_deadline(EVENT_BEFORE_DEADLINE, FUTURE_DEADLINE, require_future=False)
     mock_dt.now.assert_called_once_with(UTC)
 
 


### PR DESCRIPTION
## Problem

Rescheduling an event on the day of the event via `/modify_offkai date_time:...` failed with "❌ Event deadline must be set in the future." even though the new event time was valid and in the future.

`update_event_details()` re-validates the event's **existing, unchanged** deadline whenever the date/time is modified, using the full `validate_event_deadline()` — which includes the "deadline must be in the future" check. Once the signup deadline has legitimately passed (normal on event day), any date-only modification was rejected.

## Fix

- `validate_event_deadline()` gains a keyword-only `require_future: bool = True` parameter. When `False`, the in-the-future check is skipped but the ordering check (deadline must come before the event time) still applies.
- `update_event_details()` passes `require_future=False` when the deadline is **not** being changed. Providing a new `deadline` still gets full validation, unchanged.

Attendee data is untouched by this path — date-only modifications never renumber or alter responses.

## Tests

- Regression: event with a past deadline, date-only modification to a future time succeeds and leaves the deadline untouched.
- Util: `require_future=False` accepts a past deadline; ordering violations still raise `EventDeadlineAfterEventError`.

All gates pass: ruff, ty, 594 bot tests, frontend lint + build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DCL8EJ7AeTFWVYWPxQkuSZ