### PR TITLE
Add interest-check mode: non-binding headcount gauging for events

### DIFF
--- a/bot/src/offkai_bot/alerts/reminders.py
+++ b/bot/src/offkai_bot/alerts/reminders.py
@@ -75,7 +75,9 @@ def register_deadline_reminders(client: discord.Client, event: Event, thread: di
             register_alert(event.event_deadline, CloseOffkaiTask(client=client, event_name=event.event_name))
             _log.info("Registered auto-close task for '%s'.", event.event_name)
 
-            if event.channel_id:
+            # Interest checks are non-binding: auto-close at the deadline, but
+            # never nag the channel with countdown pings.
+            if event.channel_id and not event.interest_check:
                 role_ping = f"<@&{event.ping_role_id}> " if event.ping_role_id else ""
                 # The client-wide default suppresses all mentions; opt back in for
                 # just the configured ping role so the reminder actually notifies.
@@ -297,6 +299,10 @@ def register_checkin_reminder(client: discord.Client, event: Event) -> None:
     unregister_checkin_reminder(event.event_name)
 
     if event.archived:
+        return
+
+    # Interest checks are not real attendance — never send QR/check-in DMs.
+    if event.interest_check:
         return
 
     with contextlib.suppress(AlertTimeInPastError):

--- a/bot/src/offkai_bot/cogs/events.py
+++ b/bot/src/offkai_bot/cogs/events.py
@@ -772,7 +772,9 @@ class EventsCog(commands.Cog):
     ):
         validate_guild_context(interaction)
         await interaction.response.defer(ephemeral=True)
-        get_event(event_name)
+        event = get_event(event_name)
+        if event.interest_check:
+            raise InterestCheckOperationError(event_name, "Attendance")
         total_count, attendee_list = calculate_attendance(event_name, nicknames=nicknames, drinks=drinks, sort=sort)
 
         output = _format_attendance_output(event_name, total_count, attendee_list)
@@ -814,6 +816,8 @@ class EventsCog(commands.Cog):
         validate_guild_context(interaction)
         await interaction.response.defer(ephemeral=True)
         event = get_event(event_name)
+        if event.interest_check:
+            raise InterestCheckOperationError(event_name, "Attendance reports")
         if event.open or not has_complete_attendee_numbers(event_name):
             await interaction.followup.send(
                 "Attendee numbers are generated when an event is closed. Close the event before exporting this report.",

--- a/bot/src/offkai_bot/cogs/events.py
+++ b/bot/src/offkai_bot/cogs/events.py
@@ -45,6 +45,7 @@ from offkai_bot.errors import (
     BroadcastSendError,
     DuplicateEventError,
     EventNotFoundError,
+    InterestCheckOperationError,
     InvalidChannelTypeError,
     MissingChannelIDError,
     PinPermissionError,
@@ -272,6 +273,98 @@ class EventsCog(commands.Cog):
             _log.error("Failed to pin message due to HTTP error: %s", e)
 
     @app_commands.command(
+        name="create_interest_check",
+        description="Create a lightweight, non-binding interest check in the current channel.",
+    )
+    @app_commands.describe(
+        event_name="The name of the event.",
+        date_time="The tentative event date and time. Examples: '2024-08-15 19:30' or 'tomorrow 7pm'. Assumed JST.",
+        deadline="Optional: When the interest check auto-closes. Examples: '2024-08-15 18:00'. Assumed JST.",
+        announce_msg="Optional: A message to post in the main channel.",
+    )
+    @app_commands.checks.has_role("Offkai Organizer")
+    @log_command_usage
+    async def create_interest_check(
+        self,
+        interaction: discord.Interaction,
+        event_name: str,
+        date_time: str,
+        deadline: str | None = None,
+        announce_msg: str | None = None,
+    ):
+        # 1. Business Logic Validation
+        validate_event_name(event_name)
+        with contextlib.suppress(EventNotFoundError):
+            if get_event(event_name):
+                raise DuplicateEventError(event_name)
+
+        # 2. Input Parsing/Transformation
+        event_datetime = parse_event_datetime(date_time)
+        event_deadline = parse_event_datetime(deadline) if deadline else None
+
+        # 3. Context Validation
+        validate_interaction_context(interaction)
+        validate_event_datetime(event_datetime)
+        validate_event_deadline(event_datetime, event_deadline)
+
+        # 4. Acknowledge the interaction before the slow Discord API calls below
+        # (thread creation, event message send) exceed the 3-second window.
+        await interaction.response.defer()
+
+        # --- Discord Interaction Block ---
+        try:
+            assert isinstance(interaction.channel, discord.TextChannel)
+            thread = await interaction.channel.create_thread(name=event_name, type=discord.ChannelType.public_thread)
+        except discord.HTTPException as e:
+            _log.error("Failed to create thread for '%s': %s", event_name, e)
+            raise ThreadCreationError(event_name, e)
+        except AssertionError:
+            _log.error("Interaction channel was unexpectedly not a TextChannel after validation.")
+            raise InvalidChannelTypeError()
+        # --- End Discord Interaction Block ---
+
+        # Interest checks carry placeholder venue details: only the name, the
+        # tentative date, and the deadline matter for gauging a headcount.
+        new_event = add_event(
+            event_name=event_name,
+            venue="TBD",
+            address="TBD",
+            google_maps_link="",
+            event_datetime=event_datetime,
+            event_deadline=event_deadline,
+            channel_id=interaction.channel.id,
+            thread_id=thread.id,
+            drinks_list=[],
+            announce_msg=announce_msg,
+            max_capacity=None,
+            creator_id=interaction.user.id,
+            interest_check=True,
+        )
+
+        # Registers only the auto-close task for interest checks (see reminders.py).
+        # No check-in reminder: interest checks never send QR/check-in DMs.
+        register_deadline_reminders(self.bot, new_event, thread)
+
+        # 6. Further Discord Interaction
+        await send_event_message(thread, new_event)  # Handles saving after message send
+
+        # 7. User Feedback
+        announce_text = f"# Interest Check: {event_name}\n\n"
+        if announce_msg:
+            announce_text += f"{announce_msg}\n\n"
+        announce_text += f"Let us know if you'd be interested: {thread.mention}"
+        message = await interaction.followup.send(announce_text, wait=True)
+
+        try:
+            await message.pin()
+        except discord.Forbidden as e:
+            if message:
+                _log.warning("Failed to pin message: Missing 'Pins' permission.")
+                raise PinPermissionError(message.channel, e) from e
+        except discord.HTTPException as e:
+            _log.error("Failed to pin message due to HTTP error: %s", e)
+
+    @app_commands.command(
         name="modify_offkai",
         description="Modifies an existing offkai event.",
     )
@@ -309,6 +402,10 @@ class EventsCog(commands.Cog):
 
         old_event = get_event(event_name)
         old_capacity = old_event.max_capacity
+
+        # Interest checks have no drink or capacity machinery to configure.
+        if old_event.interest_check and (drinks is not None or max_capacity is not None):
+            raise InterestCheckOperationError(event_name, "Setting drinks or capacity")
 
         modified_event = update_event_details(
             event_name=event_name,
@@ -513,8 +610,11 @@ class EventsCog(commands.Cog):
         await interaction.response.defer(ephemeral=True)
         event = get_event(event_name)
         removed_response = remove_response(event_name, member.id)
-        decrease_rank(member.id, member.name)
         freed_spots = 1 + removed_response.extra_people
+
+        # Interest registrations never touched ranks or the waitlist.
+        if not event.interest_check:
+            decrease_rank(member.id, member.name)
 
         if event.role_id and interaction.guild:
             await remove_event_role(interaction.guild, member.id, event.role_id)
@@ -522,20 +622,27 @@ class EventsCog(commands.Cog):
         # Offer the freed spots to the waitlist, mirroring the self-withdrawal paths.
         # The delete has already persisted, so promotion failure must not fail the command.
         message = f"🚮 Deleted response from user {member.mention} for '{event_name}'."
-        try:
-            promoted_user_ids = await promote_waitlist_batch(event, self.bot, freed_spots=freed_spots)
-            if promoted_user_ids:
-                message += f"\n⬆️ Promoted {len(promoted_user_ids)} user(s) from the waitlist to fill the freed spots."
-        except Exception as e:
-            _log.error(
-                "Waitlist promotion failed after deleting response from user %s for event '%s': %s",
-                member.id,
-                event_name,
-                e,
-                exc_info=True,
-            )
-            message += "\n⚠️ Waitlist promotion failed; check the logs and promote manually if needed."
+        if not event.interest_check:
+            try:
+                promoted_user_ids = await promote_waitlist_batch(event, self.bot, freed_spots=freed_spots)
+                if promoted_user_ids:
+                    message += (
+                        f"\n⬆️ Promoted {len(promoted_user_ids)} user(s) from the waitlist to fill the freed spots."
+                    )
+            except Exception as e:
+                _log.error(
+                    "Waitlist promotion failed after deleting response from user %s for event '%s': %s",
+                    member.id,
+                    event_name,
+                    e,
+                    exc_info=True,
+                )
+                message += "\n⚠️ Waitlist promotion failed; check the logs and promote manually if needed."
         await interaction.followup.send(message, ephemeral=True)
+
+        # Keep the live interested count on the announcement accurate.
+        if event.interest_check:
+            await update_event_message(self.bot, event)
 
         if event.thread_id:
             thread = self.bot.get_channel(event.thread_id)
@@ -582,6 +689,8 @@ class EventsCog(commands.Cog):
         validate_guild_context(interaction)
         await interaction.response.defer(ephemeral=True)
         event = get_event(event_name)
+        if event.interest_check:
+            raise InterestCheckOperationError(event_name, "Waitlist promotion")
 
         try:
             user_id = int(username)
@@ -750,7 +859,9 @@ class EventsCog(commands.Cog):
         self, interaction: discord.Interaction, event_name: str, sort: bool = False, nicknames: bool = False
     ):
         validate_guild_context(interaction)
-        get_event(event_name)
+        event = get_event(event_name)
+        if event.interest_check:
+            raise InterestCheckOperationError(event_name, "The waitlist")
         total_count, waitlisted_list = calculate_waitlist(event_name, nicknames=nicknames, sort=sort)
 
         output = f"**Waitlist for {event_name}**\n\n"
@@ -772,7 +883,9 @@ class EventsCog(commands.Cog):
     @log_command_usage
     async def drinks(self, interaction: discord.Interaction, event_name: str):
         validate_guild_context(interaction)
-        get_event(event_name)
+        event = get_event(event_name)
+        if event.interest_check:
+            raise InterestCheckOperationError(event_name, "Drink tracking")
         total_count, drinks_count = calculate_drinks(event_name)
 
         output = f"**Drinks for {event_name}**\n\n"

--- a/bot/src/offkai_bot/data/event.py
+++ b/bot/src/offkai_bot/data/event.py
@@ -74,6 +74,7 @@ class Event:
     max_attendee_number: int | None = None  # Highest attendee number assigned after close
     ping_role_id: int | None = None  # Discord role ID to ping in deadline reminders
     role_id: int | None = None  # Discord role ID for event participants
+    interest_check: bool = False  # Lightweight interest gauge instead of a binding signup
 
     @property
     def has_drinks(self):
@@ -116,6 +117,15 @@ class Event:
 
         role_line = f"\n🏷️ **Role (ロール)**: <@&{self.role_id}>" if self.role_id else ""
 
+        if self.interest_check:
+            # Interest checks carry placeholder venue/address data — show only
+            # what is meaningful, and flag the date as tentative.
+            return (
+                f"📅 **Event Name (イベント名)**: {self.event_name}\n"
+                f"🕑 **Tentative Date (仮日程)**: {dt_str}\n"
+                f"📅 **Deadline (締切)**: {deadline_str}"
+            )
+
         return (
             f"📅 **Event Name (イベント名)**: {self.event_name}\n"
             f"🍽️ **Venue (会場)**: {self.venue}\n"
@@ -135,6 +145,20 @@ def create_event_message(event: Event) -> str:
     """Creates the full Discord message content for an event announcement."""
     # Use the format_details method from the Event dataclass
     event_details = event.format_details()
+
+    if event.interest_check:
+        interested_count = sum(1 + r.extra_people for r in get_responses(event.event_name))
+        message_block = f"{event.message}\n\n" if event.message else ""
+        return (
+            f"📊 **Interest Check (興味アンケート)**\n\n"
+            f"{event_details}\n\n"
+            f"{message_block}"
+            f"🙋 **Interested so far (現在の興味あり人数)**: {interested_count}\n\n"
+            "This is not a signup — we just want a rough headcount. "
+            "Click the button below if you'd be interested in coming!\n"
+            "これは参加登録ではありません。おおよその人数を把握するためのものです。"
+            "興味がある方は下のボタンをクリックしてください！"
+        )
 
     return (
         f"{event_details}\n\n"  # Event details first
@@ -265,6 +289,7 @@ def _load_event_data() -> list[Event]:
                         max_attendee_number=event_dict.get("max_attendee_number"),
                         ping_role_id=event_dict.get("ping_role_id"),
                         role_id=event_dict.get("role_id"),
+                        interest_check=event_dict.get("interest_check", False),
                     )
                 else:
                     # Old format, so we ignore channel_id and event_deadline
@@ -288,6 +313,7 @@ def _load_event_data() -> list[Event]:
                         max_attendee_number=event_dict.get("max_attendee_number"),
                         ping_role_id=event_dict.get("ping_role_id"),
                         role_id=event_dict.get("role_id"),
+                        interest_check=event_dict.get("interest_check", False),
                     )
                     _log.info(
                         "Found old events.json format for %s. Successfully converted to new format.",
@@ -399,6 +425,7 @@ def add_event(
     creator_id: int | None = None,  # Discord user ID of the event creator
     ping_role_id: int | None = None,  # Discord role ID to ping in deadline reminders
     role_id: int | None = None,  # Discord role ID for event participants
+    interest_check: bool = False,  # Lightweight interest gauge instead of a binding signup
 ) -> Event:
     """Creates an Event object and adds it to the in-memory cache."""
 
@@ -425,6 +452,7 @@ def add_event(
         creator_id=creator_id,
         ping_role_id=ping_role_id,
         role_id=role_id,
+        interest_check=interest_check,
     )
 
     # Step 3: State Modification

--- a/bot/src/offkai_bot/errors.py
+++ b/bot/src/offkai_bot/errors.py
@@ -143,6 +143,15 @@ class LegacyRankEntryNotFoundError(BotCommandError):
         super().__init__(f"❌ No legacy rank entry found for username '{legacy_username}'.")
 
 
+class InterestCheckOperationError(BotCommandError):
+    """Raised when a full-signup operation is attempted on an interest-check event."""
+
+    def __init__(self, event_name: str, operation: str):
+        self.event_name = event_name
+        self.operation = operation
+        super().__init__(f"❌ {operation} is not available for interest check '{event_name}'.")
+
+
 class NoWaitlistEntriesFoundError(BotCommandError):
     """Raised by waitlist command when no waitlist entries exist for an event."""
 

--- a/bot/src/offkai_bot/event_actions.py
+++ b/bot/src/offkai_bot/event_actions.py
@@ -8,7 +8,7 @@ from offkai_bot.data.event import (
     save_event_data,
     set_event_open_status,
 )
-from offkai_bot.data.response import assign_attendee_numbers, save_responses
+from offkai_bot.data.response import assign_attendee_numbers, get_responses, save_responses
 from offkai_bot.errors import (
     BotCommandError,
     MissingChannelIDError,
@@ -16,19 +16,53 @@ from offkai_bot.errors import (
     ThreadAccessError,
     ThreadNotFoundError,
 )
-from offkai_bot.interactions import ClosedEvent, OpenEvent, PostDeadlineEvent
+from offkai_bot.interactions import (
+    ClosedEvent,
+    InterestCheckClosedEvent,
+    InterestCheckEvent,
+    OpenEvent,
+    PostDeadlineEvent,
+)
 
 _log = logging.getLogger(__name__)
 
 
 def get_event_view(event: Event):
     """Determines the appropriate view for an event based on its state."""
+    if event.interest_check:
+        if not event.open or event.is_past_deadline:
+            return InterestCheckClosedEvent(event)
+        return InterestCheckEvent(event)
     if not event.open:
         return ClosedEvent(event)
     elif event.is_past_deadline:
         return PostDeadlineEvent(event)
     else:
         return OpenEvent(event)
+
+
+def build_interest_check_tally(event: Event) -> str:
+    """Builds the final bilingual tally message posted when an interest check closes."""
+    responses = get_responses(event.event_name)
+    total = sum(1 + r.extra_people for r in responses)
+
+    lines = []
+    for response in responses:
+        name = response.display_name or response.username
+        extras = f" (+{response.extra_people})" if response.extra_people else ""
+        lines.append(f"- {name}{extras}")
+
+    output = (
+        f"📊 **Interest check closed for {event.event_name}!**\n"
+        f"📊 **{event.event_name}の興味アンケートが終了しました！**\n\n"
+        f"🙋 **Total interested (興味あり合計)**: {total}\n"
+    )
+    if lines:
+        output += "\n" + "\n".join(lines)
+
+    if len(output) > 1900:
+        output = output[:1900] + "\n... (list truncated)"
+    return output
 
 
 async def perform_close_event(client: discord.Client, event_name: str, close_msg: str | None = None) -> Event:
@@ -62,13 +96,23 @@ async def perform_close_event(client: discord.Client, event_name: str, close_msg
     await update_event_message(client, closed_event)
     _log.info("Updated persistent message for event '%s'.", event_name)
 
-    # 4. Send closing message to thread (if provided and possible)
-    if close_msg:
+    # 4. Send closing message to thread (if applicable and possible).
+    # Interest checks always post a final tally; regular events only post
+    # when the organizer provided a closing message.
+    if closed_event.interest_check:
+        tally = build_interest_check_tally(closed_event)
+        thread_message = f"{tally}\n\n{close_msg}" if close_msg else tally
+    elif close_msg:
+        thread_message = f"**Responses Closed:**\n{close_msg}"
+    else:
+        thread_message = None
+
+    if thread_message:
         try:
             # Fetch the thread using the helper.
             thread = await fetch_thread_for_event(client, closed_event)
             try:
-                await thread.send(f"**Responses Closed:**\n{close_msg}")
+                await thread.send(thread_message)
                 _log.info("Sent closing message to thread %s for event '%s'.", thread.id, event_name)
             except discord.HTTPException as e:
                 _log.warning("Could not send closing message to thread %s for event '%s': %s", thread.id, event_name, e)

--- a/bot/src/offkai_bot/event_actions.py
+++ b/bot/src/offkai_bot/event_actions.py
@@ -25,6 +25,7 @@ from offkai_bot.interactions import (
 )
 
 _log = logging.getLogger(__name__)
+_DISCORD_MESSAGE_LIMIT = 2000
 
 
 def get_event_view(event: Event):
@@ -65,6 +66,22 @@ def build_interest_check_tally(event: Event) -> str:
     return output
 
 
+def _build_interest_check_close_message(tally: str, close_msg: str | None) -> str:
+    """Combine an interest-check tally and optional note within Discord's message limit.
+
+    The tally is the closing result, so it takes priority over an organizer's
+    optional note.  The note is truncated (or omitted) when necessary rather
+    than risking Discord rejecting the entire closing message.
+    """
+    if not close_msg:
+        return tally
+
+    available_for_close_msg = _DISCORD_MESSAGE_LIMIT - len(tally) - 2
+    if available_for_close_msg <= 0:
+        return tally
+    return f"{tally}\n\n{close_msg[:available_for_close_msg]}"
+
+
 async def perform_close_event(client: discord.Client, event_name: str, close_msg: str | None = None) -> Event:
     """
     Performs the core logic for closing an event.
@@ -85,7 +102,8 @@ async def perform_close_event(client: discord.Client, event_name: str, close_msg
 
     # 1. Update status in data store (raises EventNotFoundError if not found)
     closed_event = set_event_open_status(event_name, target_open_status=False)
-    closed_event.max_attendee_number = assign_attendee_numbers(event_name)
+    if not closed_event.interest_check:
+        closed_event.max_attendee_number = assign_attendee_numbers(event_name)
 
     # 2. Save the change
     save_responses()
@@ -101,7 +119,7 @@ async def perform_close_event(client: discord.Client, event_name: str, close_msg
     # when the organizer provided a closing message.
     if closed_event.interest_check:
         tally = build_interest_check_tally(closed_event)
-        thread_message = f"{tally}\n\n{close_msg}" if close_msg else tally
+        thread_message = _build_interest_check_close_message(tally, close_msg)
     elif close_msg:
         thread_message = f"**Responses Closed:**\n{close_msg}"
     else:

--- a/bot/src/offkai_bot/interactions.py
+++ b/bot/src/offkai_bot/interactions.py
@@ -765,6 +765,12 @@ class InterestCheckModal(ui.Modal):
 
     async def on_submit(self, interaction: discord.Interaction):
         try:
+            # The modal can remain open in a user's client after the interest
+            # check has been closed, so re-check its state at submission time.
+            if not self.event.open or self.event.is_past_deadline:
+                await error_message(interaction, "This interest check is no longer accepting responses.")
+                return
+
             num_extra_people = validate_extra_people_input(self.extra_people_input.value)
 
             new_response = Response(

--- a/bot/src/offkai_bot/interactions.py
+++ b/bot/src/offkai_bot/interactions.py
@@ -42,6 +42,20 @@ async def error_message(interaction: discord.Interaction, message: str):
     await interaction.response.send_message(f"❌ {message}", ephemeral=True)
 
 
+def validate_extra_people_input(extra_people_str: str) -> int:
+    """Validates an extra-people modal input.
+
+    Returns:
+        int specifying the number of extra people.
+
+    Raises:
+        ValidationError: If input is invalid.
+    """
+    if not extra_people_str.isdigit() or not (0 <= int(extra_people_str) <= 5):
+        raise ValidationError("Extra people must be a number between 0 and 5.")
+    return int(extra_people_str)
+
+
 async def modal_error_message(interaction: discord.Interaction, event_name: str, message: str):
     dm_message = f"❌ I couldn't process your response for **{event_name}**.\n\n{message}"
     try:
@@ -307,10 +321,7 @@ class GatheringModal(ui.Modal):
         Raises:
             ValidationError: If input is invalid.
         """
-        if not extra_people_str.isdigit() or not (0 <= int(extra_people_str) <= 5):
-            raise ValidationError("Extra people must be a number between 0 and 5.")
-        num_extra_people = int(extra_people_str)
-        return num_extra_people
+        return validate_extra_people_input(extra_people_str)
 
     def _validate_confirmations(self, behave_str: str, arrival_str: str) -> None:
         """Validates the confirmation inputs.
@@ -721,6 +732,109 @@ class GatheringModal(ui.Modal):
             # No return needed here
 
 
+class InterestCheckModal(ui.Modal):
+    """Minimal modal for interest checks: just the group size, no commitments."""
+
+    def __init__(
+        self,
+        *,
+        event: Event,
+        timeout=None,
+    ):
+        # Short "imodal_" prefix keeps the custom_id within Discord's 100-char
+        # cap for names up to MAX_EVENT_NAME_LENGTH (see GatheringModal).
+        super().__init__(
+            title=_build_modal_title(event.event_name),
+            timeout=timeout,
+            custom_id=f"imodal_{event.event_name}",
+        )
+        self.event = event
+
+        self.extra_people_input: ui.TextInput = ui.TextInput(
+            label="🧑 Extra people you'd bring (0-5)",
+            placeholder="Enter a number between 0-5",
+            required=True,
+            max_length=1,
+            custom_id="interest_extra_people",
+        )
+        self.add_item(self.extra_people_input)
+
+    @property
+    def event_name(self) -> str:
+        return self.event.event_name
+
+    async def on_submit(self, interaction: discord.Interaction):
+        try:
+            num_extra_people = validate_extra_people_input(self.extra_people_input.value)
+
+            new_response = Response(
+                user_id=interaction.user.id,
+                username=interaction.user.name,
+                extra_people=num_extra_people,
+                behavior_confirmed=False,
+                arrival_confirmed=False,
+                event_name=self.event.event_name,
+                timestamp=datetime.now(UTC),
+                drinks=[],
+                extras_names=[],
+                display_name=interaction.user.display_name,
+            )
+            add_response(self.event.event_name, new_response)
+
+            # Interest is non-binding: no DM, no rank/milestone update, no role.
+            group_size = 1 + num_extra_people
+            await interaction.response.send_message(
+                f"🙋 Thanks! You're counted as interested in **{self.event.event_name}** "
+                f"({group_size} {'person' if group_size == 1 else 'people'}).\n"
+                f"🙋 ありがとうございます！**{self.event.event_name}**に"
+                f"興味あり（{group_size}名）として記録されました。",
+                ephemeral=True,
+            )
+
+            # Add user to the thread so they can be reached for follow-ups.
+            try:
+                if interaction.channel and isinstance(interaction.channel, discord.Thread):
+                    await interaction.channel.add_user(interaction.user)
+                else:
+                    _log.warning(
+                        "Could not add user %s to thread %s (not a thread?).",
+                        interaction.user.id,
+                        interaction.channel_id,
+                    )
+            except discord.HTTPException as e:
+                _log.error("Failed to add user %s to thread %s: %s", interaction.user.id, interaction.channel_id, e)
+
+            await _refresh_interest_check_message(interaction.client, self.event)
+
+        except ValidationError as e:
+            await error_message(interaction, str(e))
+
+        except DuplicateResponseError as e:
+            # The error message already carries the ❌ prefix.
+            await interaction.response.send_message(str(e), ephemeral=True)
+
+        except Exception as e:
+            _log.error(
+                "Unexpected error during interest check submission for %s: %s",
+                self.event.event_name,
+                e,
+                exc_info=True,
+            )
+            await error_message(interaction, "An internal error occurred processing your response.")
+
+
+async def _refresh_interest_check_message(client: discord.Client, event: Event) -> None:
+    """Re-renders the interest check announcement so the live count stays current."""
+    # Imported locally: event_actions imports this module at import time.
+    from offkai_bot.event_actions import update_event_message
+
+    try:
+        await update_event_message(client, event)
+    except Exception as e:
+        # The response is already recorded; a stale count is not worth failing the interaction.
+        _log.error("Failed to refresh interest check message for '%s': %s", event.event_name, e, exc_info=True)
+
+
 # --- Views ---
 class EventView(ui.View):
     def __init__(self, event: Event):  # Expect Event object
@@ -1009,6 +1123,86 @@ class ClosedEvent(EventView):
                 e,
                 exc_info=True,
             )
+
+
+class InterestCheckEvent(EventView):
+    """View for open interest checks: non-binding register/withdraw only."""
+
+    def __init__(self, event: Event):
+        super().__init__(event=event)
+
+    @discord.ui.button(
+        label="🙋 I'm interested",
+        style=discord.ButtonStyle.success,
+        row=0,
+        custom_id="interest_button",
+    )
+    async def register_interest(self, interaction: discord.Interaction, button: discord.ui.Button):
+        await interaction.response.send_modal(InterestCheckModal(event=self.event))
+
+    @discord.ui.button(
+        label="Withdraw interest",
+        style=discord.ButtonStyle.danger,
+        row=1,
+        custom_id="interest_withdraw_button",
+    )
+    async def withdraw_interest(self, interaction: discord.Interaction, button: discord.ui.Button):
+        try:
+            remove_response(self.event.event_name, interaction.user.id)
+        except ResponseNotFoundError:
+            await error_message(
+                interaction,
+                f"You have not registered interest in **{self.event.event_name}**.",
+            )
+            return
+        except Exception as e:
+            _log.error(
+                "Unexpected error during interest withdrawal for %s by %s: %s",
+                self.event.event_name,
+                interaction.user.id,
+                e,
+                exc_info=True,
+            )
+            await error_message(interaction, "An internal error occurred while processing your withdrawal.")
+            return
+
+        # Interest is non-binding: no warning DMs, no rank change, no waitlist promotion.
+        await interaction.response.send_message(
+            f"👋 Your interest in **{self.event.event_name}** has been withdrawn.\n"
+            f"👋 **{self.event.event_name}**への興味ありが取り消されました。",
+            ephemeral=True,
+        )
+
+        try:
+            if interaction.channel and isinstance(interaction.channel, discord.Thread):
+                await interaction.channel.remove_user(interaction.user)
+        except discord.HTTPException as e:
+            _log.error(
+                "Failed to remove user %s from thread %s: %s",
+                interaction.user.id,
+                interaction.channel_id,
+                e,
+            )
+
+        await _refresh_interest_check_message(interaction.client, self.event)
+
+
+class InterestCheckClosedEvent(EventView):
+    """View for closed interest checks: the tally is a snapshot, no more input."""
+
+    def __init__(self, event: Event):
+        super().__init__(event=event)
+
+    @discord.ui.button(
+        label="Interest check closed",
+        style=discord.ButtonStyle.secondary,
+        disabled=True,
+        row=0,
+        custom_id="interest_closed_button",
+    )
+    async def closed(self, interaction: discord.Interaction, button: discord.ui.Button):
+        # This button is disabled, so this callback shouldn't trigger
+        await interaction.response.send_message("This interest check is closed.", ephemeral=True)
 
 
 class PostDeadlineEvent(EventView):

--- a/bot/tests/commands/test_create_interest_check.py
+++ b/bot/tests/commands/test_create_interest_check.py
@@ -1,0 +1,184 @@
+# tests/commands/test_create_interest_check.py
+
+from datetime import UTC, datetime, timedelta
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import discord
+import pytest
+from discord import app_commands
+from discord.ext import commands
+from offkai_bot.cogs.events import EventsCog
+from offkai_bot.data.event import Event
+from offkai_bot.errors import (
+    DuplicateEventError,
+    EventNotFoundError,
+)
+
+pytestmark = pytest.mark.asyncio
+
+
+# --- Fixtures ---
+
+
+@pytest.fixture
+def mock_cog():
+    """Fixture to create a mock EventsCog instance."""
+    bot = MagicMock(spec=commands.Bot)
+    return EventsCog(bot)
+
+
+@pytest.fixture
+def mock_interaction():
+    """Fixture to create a mock discord.Interaction with necessary attributes."""
+    interaction = MagicMock(spec=discord.Interaction)
+    interaction.user = MagicMock(spec=discord.Member)
+    interaction.user.id = 123
+    interaction.user.__str__.return_value = "TestUser#1234"
+
+    interaction.channel = MagicMock(spec=discord.TextChannel)
+    interaction.channel.id = 456
+    interaction.channel.create_thread = AsyncMock()
+
+    interaction.guild = MagicMock(spec=discord.Guild)
+    interaction.guild.id = 789
+
+    interaction.command = MagicMock(spec=app_commands.Command)
+    interaction.command.name = "create_interest_check"
+
+    interaction.response = MagicMock()
+    interaction.response.send_message = AsyncMock()
+    interaction.response.defer = AsyncMock()
+    interaction.followup = MagicMock()
+    interaction.followup.send = AsyncMock(return_value=MagicMock(spec=discord.Message))
+
+    return interaction
+
+
+@pytest.fixture
+def mock_thread():
+    """Fixture for a mock discord.Thread."""
+    thread = MagicMock(spec=discord.Thread)
+    thread.id = 111222333
+    thread.mention = "<#111222333>"
+    thread.send = AsyncMock()
+    return thread
+
+
+@pytest.fixture
+def mock_created_interest_event():
+    """Fixture for the Event object returned by add_event."""
+    now = datetime.now(UTC)
+    event_dt = now + timedelta(days=30)
+    deadline_dt = event_dt - timedelta(days=7)
+    return Event(
+        event_name="Test Interest Check",
+        venue="TBD",
+        address="TBD",
+        google_maps_link="",
+        event_datetime=event_dt,
+        event_deadline=deadline_dt,
+        channel_id=456,
+        thread_id=111222333,
+        message_id=None,
+        open=True,
+        archived=False,
+        drinks=[],
+        message="Announce",
+        max_capacity=None,
+        interest_check=True,
+    )
+
+
+# --- Test Cases ---
+
+
+@patch("offkai_bot.cogs.events.send_event_message", new_callable=AsyncMock)
+@patch("offkai_bot.cogs.events.register_checkin_reminder")
+@patch("offkai_bot.cogs.events.register_deadline_reminders")
+@patch("offkai_bot.cogs.events.add_event")
+@patch("offkai_bot.cogs.events.validate_interaction_context")
+@patch("offkai_bot.cogs.events.parse_event_datetime")
+@patch("offkai_bot.cogs.events.get_event")
+@patch("offkai_bot.cogs.events._log")
+async def test_create_interest_check_success(
+    mock_log,
+    mock_get_event,
+    mock_parse_dt,
+    mock_validate_ctx,
+    mock_add_event,
+    mock_register_reminders,
+    mock_register_checkin,
+    mock_send_event_message,
+    mock_interaction,
+    mock_thread,
+    mock_created_interest_event,
+    mock_cog,
+):
+    """Interest check creation stores placeholders, sets the flag, and skips check-in reminders."""
+    # Arrange
+    event = mock_created_interest_event
+    mock_get_event.side_effect = EventNotFoundError(event.event_name)
+    mock_parse_dt.side_effect = [event.event_datetime, event.event_deadline]
+    mock_interaction.channel.create_thread.return_value = mock_thread
+    mock_add_event.return_value = event
+
+    # Act
+    await EventsCog.create_interest_check.callback(
+        mock_cog,
+        mock_interaction,
+        event_name=event.event_name,
+        date_time="2030-08-15 19:30",
+        deadline="2030-08-08 19:30",
+        announce_msg="Announce",
+    )
+
+    # Assert
+    mock_add_event.assert_called_once_with(
+        event_name=event.event_name,
+        venue="TBD",
+        address="TBD",
+        google_maps_link="",
+        event_datetime=event.event_datetime,
+        event_deadline=event.event_deadline,
+        channel_id=mock_interaction.channel.id,
+        thread_id=mock_thread.id,
+        drinks_list=[],
+        announce_msg="Announce",
+        max_capacity=None,
+        creator_id=mock_interaction.user.id,
+        interest_check=True,
+    )
+    mock_register_reminders.assert_called_once_with(mock_cog.bot, event, mock_thread)
+    # Interest checks never send QR/check-in DMs.
+    mock_register_checkin.assert_not_called()
+    mock_send_event_message.assert_awaited_once_with(mock_thread, event)
+
+    # Announcement posted and pinned.
+    mock_interaction.followup.send.assert_awaited_once()
+    announce_text = mock_interaction.followup.send.call_args[0][0]
+    assert announce_text.startswith("# Interest Check: ")
+    assert mock_thread.mention in announce_text
+    mock_interaction.followup.send.return_value.pin.assert_awaited_once()
+
+
+@patch("offkai_bot.cogs.events.parse_event_datetime")
+@patch("offkai_bot.cogs.events.get_event")
+async def test_create_interest_check_duplicate_name(
+    mock_get_event,
+    mock_parse_dt,
+    mock_interaction,
+    mock_created_interest_event,
+    mock_cog,
+):
+    """A pre-existing event with the same name is rejected."""
+    mock_get_event.return_value = mock_created_interest_event
+
+    with pytest.raises(DuplicateEventError):
+        await EventsCog.create_interest_check.callback(
+            mock_cog,
+            mock_interaction,
+            event_name=mock_created_interest_event.event_name,
+            date_time="2030-08-15 19:30",
+        )
+
+    mock_interaction.channel.create_thread.assert_not_called()

--- a/bot/tests/commands/test_interest_check_guards.py
+++ b/bot/tests/commands/test_interest_check_guards.py
@@ -1,0 +1,184 @@
+# tests/commands/test_interest_check_guards.py
+"""Full-signup commands must refuse (or degrade gracefully for) interest-check events."""
+
+from datetime import UTC, datetime, timedelta
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import discord
+import pytest
+from discord import app_commands
+from discord.ext import commands
+from offkai_bot.cogs.events import EventsCog
+from offkai_bot.data.event import Event
+from offkai_bot.errors import InterestCheckOperationError
+
+pytestmark = pytest.mark.asyncio
+
+
+# --- Fixtures ---
+
+
+@pytest.fixture
+def mock_cog():
+    """Fixture to create a mock EventsCog instance."""
+    bot = MagicMock(spec=commands.Bot)
+    return EventsCog(bot)
+
+
+@pytest.fixture
+def mock_interaction():
+    """Fixture to create a mock discord.Interaction with necessary attributes."""
+    interaction = MagicMock(spec=discord.Interaction)
+    interaction.user = MagicMock(spec=discord.Member)
+    interaction.user.id = 123
+    interaction.user.__str__.return_value = "TestUser#1234"
+
+    interaction.channel = MagicMock(spec=discord.TextChannel)
+    interaction.channel.id = 456
+
+    interaction.guild = MagicMock(spec=discord.Guild)
+    interaction.guild.id = 789
+
+    interaction.command = MagicMock(spec=app_commands.Command)
+    interaction.command.name = "test_command"
+
+    interaction.response = MagicMock()
+    interaction.response.send_message = AsyncMock()
+    interaction.response.defer = AsyncMock()
+    interaction.followup = MagicMock(send=AsyncMock())
+
+    return interaction
+
+
+@pytest.fixture
+def interest_event():
+    now = datetime.now(UTC)
+    return Event(
+        event_name="Interest Test",
+        venue="TBD",
+        address="TBD",
+        google_maps_link="",
+        event_datetime=now + timedelta(days=30),
+        event_deadline=now + timedelta(days=7),
+        channel_id=456,
+        thread_id=789,
+        message_id=None,
+        open=True,
+        archived=False,
+        drinks=[],
+        max_capacity=None,
+        interest_check=True,
+    )
+
+
+# --- Guard Tests ---
+
+
+@patch("offkai_bot.cogs.events.get_event")
+async def test_promote_rejected_for_interest_check(mock_get_event, mock_interaction, interest_event, mock_cog):
+    mock_get_event.return_value = interest_event
+
+    with pytest.raises(InterestCheckOperationError):
+        await EventsCog.promote.callback(
+            mock_cog, mock_interaction, event_name=interest_event.event_name, username="98765"
+        )
+
+
+@patch("offkai_bot.cogs.events.calculate_waitlist")
+@patch("offkai_bot.cogs.events.get_event")
+async def test_waitlist_rejected_for_interest_check(
+    mock_get_event, mock_calculate_waitlist, mock_interaction, interest_event, mock_cog
+):
+    mock_get_event.return_value = interest_event
+
+    with pytest.raises(InterestCheckOperationError):
+        await EventsCog.waitlist.callback(mock_cog, mock_interaction, event_name=interest_event.event_name)
+
+    mock_calculate_waitlist.assert_not_called()
+
+
+@patch("offkai_bot.cogs.events.calculate_drinks")
+@patch("offkai_bot.cogs.events.get_event")
+async def test_drinks_rejected_for_interest_check(
+    mock_get_event, mock_calculate_drinks, mock_interaction, interest_event, mock_cog
+):
+    mock_get_event.return_value = interest_event
+
+    with pytest.raises(InterestCheckOperationError):
+        await EventsCog.drinks.callback(mock_cog, mock_interaction, event_name=interest_event.event_name)
+
+    mock_calculate_drinks.assert_not_called()
+
+
+@patch("offkai_bot.cogs.events.update_event_details")
+@patch("offkai_bot.cogs.events.get_event")
+@patch("offkai_bot.cogs.events.validate_interaction_context")
+async def test_modify_rejects_capacity_for_interest_check(
+    mock_validate_ctx, mock_get_event, mock_update_details, mock_interaction, interest_event, mock_cog
+):
+    mock_get_event.return_value = interest_event
+
+    with pytest.raises(InterestCheckOperationError):
+        await EventsCog.modify_offkai.callback(
+            mock_cog,
+            mock_interaction,
+            event_name=interest_event.event_name,
+            update_msg="update",
+            max_capacity=20,
+        )
+
+    mock_update_details.assert_not_called()
+
+
+@patch("offkai_bot.cogs.events.update_event_details")
+@patch("offkai_bot.cogs.events.get_event")
+@patch("offkai_bot.cogs.events.validate_interaction_context")
+async def test_modify_rejects_drinks_for_interest_check(
+    mock_validate_ctx, mock_get_event, mock_update_details, mock_interaction, interest_event, mock_cog
+):
+    mock_get_event.return_value = interest_event
+
+    with pytest.raises(InterestCheckOperationError):
+        await EventsCog.modify_offkai.callback(
+            mock_cog,
+            mock_interaction,
+            event_name=interest_event.event_name,
+            update_msg="update",
+            drinks="Beer, Wine",
+        )
+
+    mock_update_details.assert_not_called()
+
+
+@patch("offkai_bot.cogs.events.update_event_message", new_callable=AsyncMock)
+@patch("offkai_bot.cogs.events.promote_waitlist_batch", new_callable=AsyncMock)
+@patch("offkai_bot.cogs.events.decrease_rank")
+@patch("offkai_bot.cogs.events.remove_response")
+@patch("offkai_bot.cogs.events.get_event")
+async def test_delete_response_interest_check_skips_rank_and_promotion(
+    mock_get_event,
+    mock_remove_response,
+    mock_decrease_rank,
+    mock_promote,
+    mock_update_message,
+    mock_interaction,
+    interest_event,
+    mock_cog,
+):
+    mock_get_event.return_value = interest_event
+    mock_remove_response.return_value = MagicMock(extra_people=1)
+    member = MagicMock(spec=discord.Member)
+    member.id = 98765
+    member.mention = "<@98765>"
+    mock_cog.bot.get_channel.return_value = MagicMock(spec=discord.Thread, remove_user=AsyncMock())
+
+    await EventsCog.delete_response.callback(
+        mock_cog, mock_interaction, event_name=interest_event.event_name, member=member
+    )
+
+    mock_remove_response.assert_called_once_with(interest_event.event_name, member.id)
+    mock_decrease_rank.assert_not_called()
+    mock_promote.assert_not_awaited()
+    # The live interested count on the announcement is refreshed.
+    mock_update_message.assert_awaited_once_with(mock_cog.bot, interest_event)
+    mock_interaction.followup.send.assert_awaited_once()

--- a/bot/tests/commands/test_interest_check_guards.py
+++ b/bot/tests/commands/test_interest_check_guards.py
@@ -110,6 +110,34 @@ async def test_drinks_rejected_for_interest_check(
     mock_calculate_drinks.assert_not_called()
 
 
+@patch("offkai_bot.cogs.events.calculate_attendance")
+@patch("offkai_bot.cogs.events.get_event")
+async def test_attendance_rejected_for_interest_check(
+    mock_get_event, mock_calculate_attendance, mock_interaction, interest_event, mock_cog
+):
+    mock_get_event.return_value = interest_event
+
+    with pytest.raises(InterestCheckOperationError):
+        await EventsCog.attendance.callback(mock_cog, mock_interaction, event_name=interest_event.event_name)
+
+    mock_calculate_attendance.assert_not_called()
+
+
+@patch("offkai_bot.cogs.events.build_attendee_report_rows")
+@patch("offkai_bot.cogs.events.has_complete_attendee_numbers")
+@patch("offkai_bot.cogs.events.get_event")
+async def test_attendance_report_rejected_for_interest_check(
+    mock_get_event, mock_has_complete_numbers, mock_build_report_rows, mock_interaction, interest_event, mock_cog
+):
+    mock_get_event.return_value = interest_event
+
+    with pytest.raises(InterestCheckOperationError):
+        await EventsCog.attendance_report.callback(mock_cog, mock_interaction, event_name=interest_event.event_name)
+
+    mock_has_complete_numbers.assert_not_called()
+    mock_build_report_rows.assert_not_called()
+
+
 @patch("offkai_bot.cogs.events.update_event_details")
 @patch("offkai_bot.cogs.events.get_event")
 @patch("offkai_bot.cogs.events.validate_interaction_context")

--- a/bot/tests/data/test_event.py
+++ b/bot/tests/data/test_event.py
@@ -1510,6 +1510,72 @@ def test_create_event_message():
     assert actual_message == expected_message
 
 
+# == interest_check field Tests ==
+
+
+def test_load_event_data_interest_check_defaults_false(mock_paths):
+    """Old JSON without the interest_check key loads as a regular event."""
+    dt1 = datetime(2024, 8, 1, 19, 0, tzinfo=UTC)
+    event_dict = {
+        "event_name": "Legacy Event",
+        "venue": "V1",
+        "address": "A1",
+        "google_maps_link": "g1",
+        "event_datetime": dt1.isoformat(),
+        "event_deadline": None,
+        "channel_id": 1,
+        "thread_id": 11,
+        "message_id": 111,
+        "open": True,
+        "archived": False,
+        "drinks": [],
+    }
+    valid_json = json.dumps([event_dict], indent=4)
+
+    with (
+        patch("os.path.exists", return_value=True),
+        patch("os.path.getsize", return_value=100),
+        patch("builtins.open", mock_open(read_data=valid_json)),
+        patch("offkai_bot.data.event._log"),
+    ):
+        events = event_data._load_event_data()
+
+    assert len(events) == 1
+    assert events[0].interest_check is False
+
+
+def test_load_event_data_interest_check_true_round_trips(mock_paths):
+    """An interest_check flag persisted in JSON is loaded back."""
+    dt1 = datetime(2024, 8, 1, 19, 0, tzinfo=UTC)
+    event_dict = {
+        "event_name": "Interest Event",
+        "venue": "TBD",
+        "address": "TBD",
+        "google_maps_link": "",
+        "event_datetime": dt1.isoformat(),
+        "event_deadline": None,
+        "channel_id": 1,
+        "thread_id": 11,
+        "message_id": 111,
+        "open": True,
+        "archived": False,
+        "drinks": [],
+        "interest_check": True,
+    }
+    valid_json = json.dumps([event_dict], indent=4)
+
+    with (
+        patch("os.path.exists", return_value=True),
+        patch("os.path.getsize", return_value=100),
+        patch("builtins.open", mock_open(read_data=valid_json)),
+        patch("offkai_bot.data.event._log"),
+    ):
+        events = event_data._load_event_data()
+
+    assert len(events) == 1
+    assert events[0].interest_check is True
+
+
 def test_create_event_message_with_deadline():
     # Simulate event/deadline times (e.g., JST) stored as UTC
     event_naive_jst = datetime(2024, 8, 1, 12, 0, 0)

--- a/bot/tests/test_event_actions.py
+++ b/bot/tests/test_event_actions.py
@@ -43,7 +43,11 @@ def mock_thread():
 @pytest.fixture
 def mock_event():
     """Fixture for a generic mock Event object."""
-    return MagicMock(spec=Event)
+    event = MagicMock(spec=Event)
+    # A bare MagicMock attribute is truthy, which would misroute get_event_view
+    # into the interest-check branch.
+    event.interest_check = False
+    return event
 
 
 @pytest.fixture

--- a/bot/tests/test_interest_check.py
+++ b/bot/tests/test_interest_check.py
@@ -1,0 +1,416 @@
+"""Tests for the interest-check mode: modal, views, dispatch, templates, tally, reminders."""
+
+from datetime import UTC, datetime, timedelta
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import discord
+import pytest
+from offkai_bot.alerts.reminders import register_checkin_reminder, register_deadline_reminders
+from offkai_bot.alerts.task import CloseOffkaiTask
+from offkai_bot.data.event import Event, create_event_message
+from offkai_bot.data.response import Response
+from offkai_bot.errors import DuplicateResponseError, ResponseNotFoundError
+from offkai_bot.event_actions import build_interest_check_tally, get_event_view, perform_close_event
+from offkai_bot.interactions import (
+    ClosedEvent,
+    InterestCheckClosedEvent,
+    InterestCheckEvent,
+    InterestCheckModal,
+    OpenEvent,
+    ValidationError,
+    validate_extra_people_input,
+)
+
+from offkai_bot.alerts import alerts
+
+# asyncio_mode = "auto" runs the async tests here without an explicit mark;
+# a module-level asyncio pytestmark would warn on this file's sync tests.
+
+# --- Fixtures ---
+
+
+def make_interest_event(
+    *,
+    event_name: str = "Interest Test",
+    open_: bool = True,
+    deadline_offset: timedelta = timedelta(days=7),
+) -> Event:
+    now = datetime.now(UTC)
+    return Event(
+        event_name=event_name,
+        venue="TBD",
+        address="TBD",
+        google_maps_link="",
+        event_datetime=now + timedelta(days=30),
+        event_deadline=now + deadline_offset,
+        channel_id=456,
+        thread_id=789,
+        message_id=None,
+        open=open_,
+        archived=False,
+        drinks=[],
+        max_capacity=None,
+        interest_check=True,
+    )
+
+
+def make_response(user_id: int, username: str, extra_people: int = 0, display_name: str | None = None) -> Response:
+    return Response(
+        user_id=user_id,
+        username=username,
+        extra_people=extra_people,
+        behavior_confirmed=False,
+        arrival_confirmed=False,
+        event_name="Interest Test",
+        timestamp=datetime.now(UTC),
+        drinks=[],
+        extras_names=[],
+        display_name=display_name,
+    )
+
+
+@pytest.fixture
+def mock_interaction():
+    interaction = MagicMock(spec=discord.Interaction)
+    interaction.user = MagicMock(spec=discord.Member)
+    interaction.user.id = 123
+    interaction.user.name = "TestUser"
+    interaction.user.display_name = "Test Display"
+    interaction.user.send = AsyncMock()
+    interaction.channel = MagicMock(spec=discord.Thread)
+    interaction.channel.id = 789
+    interaction.channel.add_user = AsyncMock()
+    interaction.channel.remove_user = AsyncMock()
+    interaction.channel_id = 789
+    interaction.response = MagicMock()
+    interaction.response.send_message = AsyncMock()
+    interaction.client = MagicMock(spec=discord.Client)
+    return interaction
+
+
+# --- validate_extra_people_input ---
+
+
+def test_validate_extra_people_input_accepts_range():
+    assert validate_extra_people_input("0") == 0
+    assert validate_extra_people_input("5") == 5
+
+
+@pytest.mark.parametrize("bad_input", ["6", "-1", "x", "", "1.5"])
+def test_validate_extra_people_input_rejects_invalid(bad_input):
+    with pytest.raises(ValidationError):
+        validate_extra_people_input(bad_input)
+
+
+# --- InterestCheckModal construction ---
+
+
+async def test_interest_modal_custom_id_uses_short_prefix():
+    event = make_interest_event()
+    modal = InterestCheckModal(event=event)
+    assert modal.custom_id == f"imodal_{event.event_name}"
+
+
+async def test_interest_modal_custom_id_fits_discord_limit_for_max_length_name():
+    from offkai_bot.util import MAX_EVENT_NAME_LENGTH
+
+    event = make_interest_event(event_name="a" * MAX_EVENT_NAME_LENGTH)
+    modal = InterestCheckModal(event=event)
+    assert len(modal.custom_id) <= 100
+    assert len(modal.title) <= 45
+
+
+# --- InterestCheckModal.on_submit ---
+
+
+@patch("offkai_bot.interactions._refresh_interest_check_message", new_callable=AsyncMock)
+@patch("offkai_bot.interactions.update_rank")
+@patch("offkai_bot.interactions.add_response")
+async def test_interest_modal_submit_records_noncommittal_response(
+    mock_add_response, mock_update_rank, mock_refresh, mock_interaction
+):
+    event = make_interest_event()
+    modal = InterestCheckModal(event=event)
+    modal.extra_people_input = MagicMock()
+    modal.extra_people_input.value = "2"
+
+    await modal.on_submit(mock_interaction)
+
+    mock_add_response.assert_called_once()
+    recorded = mock_add_response.call_args[0][1]
+    assert recorded.extra_people == 2
+    assert recorded.behavior_confirmed is False
+    assert recorded.arrival_confirmed is False
+    assert recorded.drinks == []
+    assert recorded.extras_names == []
+
+    # Non-binding: no rank/milestone machinery, no DM.
+    mock_update_rank.assert_not_called()
+    mock_interaction.user.send.assert_not_called()
+
+    # Ephemeral confirmation, user added to thread, live count refreshed.
+    mock_interaction.response.send_message.assert_awaited_once()
+    assert mock_interaction.response.send_message.call_args.kwargs.get("ephemeral") is True
+    mock_interaction.channel.add_user.assert_awaited_once_with(mock_interaction.user)
+    mock_refresh.assert_awaited_once_with(mock_interaction.client, event)
+
+
+@patch("offkai_bot.interactions._refresh_interest_check_message", new_callable=AsyncMock)
+@patch("offkai_bot.interactions.add_response")
+async def test_interest_modal_submit_rejects_invalid_extra_people(mock_add_response, mock_refresh, mock_interaction):
+    modal = InterestCheckModal(event=make_interest_event())
+    modal.extra_people_input = MagicMock()
+    modal.extra_people_input.value = "9"
+
+    await modal.on_submit(mock_interaction)
+
+    mock_add_response.assert_not_called()
+    mock_refresh.assert_not_called()
+    mock_interaction.response.send_message.assert_awaited_once()
+    assert "between 0 and 5" in mock_interaction.response.send_message.call_args[0][0]
+
+
+@patch("offkai_bot.interactions._refresh_interest_check_message", new_callable=AsyncMock)
+@patch("offkai_bot.interactions.add_response")
+async def test_interest_modal_submit_duplicate_is_ephemeral_error(mock_add_response, mock_refresh, mock_interaction):
+    event = make_interest_event()
+    mock_add_response.side_effect = DuplicateResponseError(event.event_name, 123)
+    modal = InterestCheckModal(event=event)
+    modal.extra_people_input = MagicMock()
+    modal.extra_people_input.value = "0"
+
+    await modal.on_submit(mock_interaction)
+
+    mock_refresh.assert_not_called()
+    mock_interaction.response.send_message.assert_awaited_once()
+    assert "already submitted" in mock_interaction.response.send_message.call_args[0][0]
+    assert mock_interaction.response.send_message.call_args.kwargs.get("ephemeral") is True
+
+
+# --- InterestCheckEvent.withdraw_interest ---
+
+
+@patch("offkai_bot.interactions._refresh_interest_check_message", new_callable=AsyncMock)
+@patch("offkai_bot.interactions.decrease_rank")
+@patch("offkai_bot.interactions.promote_waitlist_batch", new_callable=AsyncMock)
+@patch("offkai_bot.interactions.remove_response")
+async def test_interest_withdraw_success_skips_rank_and_promotion(
+    mock_remove_response, mock_promote, mock_decrease_rank, mock_refresh, mock_interaction
+):
+    event = make_interest_event()
+    view = InterestCheckEvent(event)
+
+    await view.withdraw_interest.callback(mock_interaction)
+
+    mock_remove_response.assert_called_once_with(event.event_name, mock_interaction.user.id)
+    mock_decrease_rank.assert_not_called()
+    mock_promote.assert_not_awaited()
+    mock_interaction.response.send_message.assert_awaited_once()
+    assert mock_interaction.response.send_message.call_args.kwargs.get("ephemeral") is True
+    mock_interaction.channel.remove_user.assert_awaited_once_with(mock_interaction.user)
+    mock_refresh.assert_awaited_once_with(mock_interaction.client, event)
+
+
+@patch("offkai_bot.interactions._refresh_interest_check_message", new_callable=AsyncMock)
+@patch("offkai_bot.interactions.remove_response")
+async def test_interest_withdraw_not_registered(mock_remove_response, mock_refresh, mock_interaction):
+    event = make_interest_event()
+    mock_remove_response.side_effect = ResponseNotFoundError(event.event_name, 123)
+    view = InterestCheckEvent(event)
+
+    await view.withdraw_interest.callback(mock_interaction)
+
+    mock_refresh.assert_not_awaited()
+    mock_interaction.response.send_message.assert_awaited_once()
+    assert "have not registered interest" in mock_interaction.response.send_message.call_args[0][0]
+
+
+# --- get_event_view dispatch (restart-persistence path) ---
+
+
+async def test_get_event_view_open_interest_check():
+    view = get_event_view(make_interest_event())
+    assert isinstance(view, InterestCheckEvent)
+
+
+async def test_get_event_view_closed_interest_check():
+    view = get_event_view(make_interest_event(open_=False))
+    assert isinstance(view, InterestCheckClosedEvent)
+
+
+async def test_get_event_view_past_deadline_interest_check():
+    view = get_event_view(make_interest_event(deadline_offset=timedelta(days=-1)))
+    assert isinstance(view, InterestCheckClosedEvent)
+
+
+async def test_get_event_view_regular_events_unchanged():
+    regular = make_interest_event()
+    regular.interest_check = False
+    assert isinstance(get_event_view(regular), OpenEvent)
+    regular.open = False
+    assert isinstance(get_event_view(regular), ClosedEvent)
+
+
+# --- create_event_message interest template ---
+
+
+@patch("offkai_bot.data.event.get_responses")
+def test_create_event_message_interest_template_shows_live_count(mock_get_responses):
+    event = make_interest_event()
+    mock_get_responses.return_value = [
+        make_response(1, "alice", extra_people=2),
+        make_response(2, "bob", extra_people=0),
+    ]
+
+    content = create_event_message(event)
+
+    assert "Interest Check" in content
+    assert "Interested so far (現在の興味あり人数)**: 4" in content
+    # No binding-signup boilerplate.
+    assert "split the bill" not in content
+    assert "confirm your attendance" not in content
+    # Placeholder venue details are omitted.
+    assert "TBD" not in content
+    assert "Tentative Date" in content
+
+
+@patch("offkai_bot.data.event.get_responses")
+def test_create_event_message_interest_template_count_updates(mock_get_responses):
+    event = make_interest_event()
+
+    mock_get_responses.return_value = []
+    assert "Interested so far (現在の興味あり人数)**: 0" in create_event_message(event)
+
+    mock_get_responses.return_value = [make_response(1, "alice", extra_people=1)]
+    assert "Interested so far (現在の興味あり人数)**: 2" in create_event_message(event)
+
+
+@patch("offkai_bot.data.event.get_responses")
+def test_create_event_message_regular_event_unchanged(mock_get_responses):
+    event = make_interest_event()
+    event.interest_check = False
+
+    content = create_event_message(event)
+
+    mock_get_responses.assert_not_called()
+    assert "Click the button below to confirm your attendance!" in content
+
+
+# --- build_interest_check_tally / perform_close_event ---
+
+
+@patch("offkai_bot.event_actions.get_responses")
+def test_build_interest_check_tally_lists_names_and_total(mock_get_responses):
+    event = make_interest_event()
+    mock_get_responses.return_value = [
+        make_response(1, "alice", extra_people=2, display_name="Alice"),
+        make_response(2, "bob", extra_people=0),
+    ]
+
+    tally = build_interest_check_tally(event)
+
+    assert "Interest check closed" in tally
+    assert "**Total interested (興味あり合計)**: 4" in tally
+    assert "- Alice (+2)" in tally
+    assert "- bob" in tally
+
+
+@patch("offkai_bot.event_actions.get_responses")
+def test_build_interest_check_tally_empty(mock_get_responses):
+    mock_get_responses.return_value = []
+
+    tally = build_interest_check_tally(make_interest_event())
+
+    assert "**Total interested (興味あり合計)**: 0" in tally
+
+
+@patch("offkai_bot.event_actions.get_responses")
+@patch("offkai_bot.event_actions.fetch_thread_for_event", new_callable=AsyncMock)
+@patch("offkai_bot.event_actions.update_event_message", new_callable=AsyncMock)
+@patch("offkai_bot.event_actions.save_event_data")
+@patch("offkai_bot.event_actions.save_responses")
+@patch("offkai_bot.event_actions.assign_attendee_numbers")
+@patch("offkai_bot.event_actions.set_event_open_status")
+async def test_perform_close_event_posts_tally_for_interest_check(
+    mock_set_status,
+    mock_assign_numbers,
+    mock_save_responses,
+    mock_save_event_data,
+    mock_update_message,
+    mock_fetch_thread,
+    mock_get_responses,
+):
+    event = make_interest_event(open_=False)
+    mock_set_status.return_value = event
+    mock_assign_numbers.return_value = None
+    mock_get_responses.return_value = [make_response(1, "alice", extra_people=1)]
+    mock_thread = MagicMock(spec=discord.Thread)
+    mock_thread.send = AsyncMock()
+    mock_fetch_thread.return_value = mock_thread
+
+    client = MagicMock(spec=discord.Client)
+    await perform_close_event(client, event.event_name)
+
+    mock_thread.send.assert_awaited_once()
+    sent = mock_thread.send.call_args[0][0]
+    assert "Interest check closed" in sent
+    assert "**Total interested (興味あり合計)**: 2" in sent
+
+
+@patch("offkai_bot.event_actions.fetch_thread_for_event", new_callable=AsyncMock)
+@patch("offkai_bot.event_actions.update_event_message", new_callable=AsyncMock)
+@patch("offkai_bot.event_actions.save_event_data")
+@patch("offkai_bot.event_actions.save_responses")
+@patch("offkai_bot.event_actions.assign_attendee_numbers")
+@patch("offkai_bot.event_actions.set_event_open_status")
+async def test_perform_close_event_regular_event_without_msg_sends_nothing(
+    mock_set_status,
+    mock_assign_numbers,
+    mock_save_responses,
+    mock_save_event_data,
+    mock_update_message,
+    mock_fetch_thread,
+):
+    event = make_interest_event(open_=False)
+    event.interest_check = False
+    mock_set_status.return_value = event
+
+    client = MagicMock(spec=discord.Client)
+    await perform_close_event(client, event.event_name)
+
+    mock_fetch_thread.assert_not_awaited()
+
+
+# --- Reminder registration ---
+
+
+def test_register_deadline_reminders_interest_check_only_auto_close(mock_thread):
+    client = MagicMock(spec=discord.Client)
+    event = make_interest_event(deadline_offset=timedelta(days=10))
+
+    register_deadline_reminders(client, event, mock_thread)
+
+    registered = [task for tasks in alerts._scheduled_tasks.values() for task in tasks]
+    assert len(registered) == 1
+    assert isinstance(registered[0], CloseOffkaiTask)
+
+
+def test_register_deadline_reminders_regular_event_registers_pings(mock_thread):
+    client = MagicMock(spec=discord.Client)
+    event = make_interest_event(deadline_offset=timedelta(days=10))
+    event.interest_check = False
+
+    register_deadline_reminders(client, event, mock_thread)
+
+    registered = [task for tasks in alerts._scheduled_tasks.values() for task in tasks]
+    # Auto-close + 24h/3d/7d pings
+    assert len(registered) == 4
+
+
+def test_register_checkin_reminder_skipped_for_interest_check():
+    client = MagicMock(spec=discord.Client)
+    event = make_interest_event()
+
+    register_checkin_reminder(client, event)
+
+    assert not any(tasks for tasks in alerts._scheduled_tasks.values())

--- a/bot/tests/test_interest_check.py
+++ b/bot/tests/test_interest_check.py
@@ -170,6 +170,33 @@ async def test_interest_modal_submit_rejects_invalid_extra_people(mock_add_respo
     assert "between 0 and 5" in mock_interaction.response.send_message.call_args[0][0]
 
 
+@pytest.mark.parametrize(
+    "event",
+    [
+        make_interest_event(open_=False),
+        make_interest_event(deadline_offset=timedelta(days=-1)),
+    ],
+    ids=["manually_closed", "past_deadline"],
+)
+@patch("offkai_bot.interactions._refresh_interest_check_message", new_callable=AsyncMock)
+@patch("offkai_bot.interactions.add_response")
+async def test_interest_modal_submit_rejects_closed_interest_check(
+    mock_add_response, mock_refresh, mock_interaction, event
+):
+    modal = InterestCheckModal(event=event)
+    modal.extra_people_input = MagicMock()
+    modal.extra_people_input.value = "2"
+
+    await modal.on_submit(mock_interaction)
+
+    mock_add_response.assert_not_called()
+    mock_refresh.assert_not_awaited()
+    mock_interaction.channel.add_user.assert_not_awaited()
+    mock_interaction.response.send_message.assert_awaited_once()
+    assert "no longer accepting responses" in mock_interaction.response.send_message.call_args[0][0]
+    assert mock_interaction.response.send_message.call_args.kwargs.get("ephemeral") is True
+
+
 @patch("offkai_bot.interactions._refresh_interest_check_message", new_callable=AsyncMock)
 @patch("offkai_bot.interactions.add_response")
 async def test_interest_modal_submit_duplicate_is_ephemeral_error(mock_add_response, mock_refresh, mock_interaction):
@@ -325,6 +352,17 @@ def test_build_interest_check_tally_empty(mock_get_responses):
 
 
 @patch("offkai_bot.event_actions.get_responses")
+def test_build_interest_check_tally_truncates_long_response_list(mock_get_responses):
+    mock_get_responses.return_value = [make_response(index, "a" * 100) for index in range(30)]
+
+    tally = build_interest_check_tally(make_interest_event())
+
+    assert len(tally) <= 2000
+    assert "**Total interested (興味あり合計)**: 30" in tally
+    assert tally.endswith("... (list truncated)")
+
+
+@patch("offkai_bot.event_actions.get_responses")
 @patch("offkai_bot.event_actions.fetch_thread_for_event", new_callable=AsyncMock)
 @patch("offkai_bot.event_actions.update_event_message", new_callable=AsyncMock)
 @patch("offkai_bot.event_actions.save_event_data")
@@ -351,10 +389,45 @@ async def test_perform_close_event_posts_tally_for_interest_check(
     client = MagicMock(spec=discord.Client)
     await perform_close_event(client, event.event_name)
 
+    mock_assign_numbers.assert_not_called()
+    assert event.max_attendee_number is None
     mock_thread.send.assert_awaited_once()
     sent = mock_thread.send.call_args[0][0]
     assert "Interest check closed" in sent
     assert "**Total interested (興味あり合計)**: 2" in sent
+
+
+@patch("offkai_bot.event_actions.get_responses")
+@patch("offkai_bot.event_actions.fetch_thread_for_event", new_callable=AsyncMock)
+@patch("offkai_bot.event_actions.update_event_message", new_callable=AsyncMock)
+@patch("offkai_bot.event_actions.save_event_data")
+@patch("offkai_bot.event_actions.save_responses")
+@patch("offkai_bot.event_actions.assign_attendee_numbers")
+@patch("offkai_bot.event_actions.set_event_open_status")
+async def test_perform_close_interest_check_truncates_long_close_message(
+    mock_set_status,
+    mock_assign_numbers,
+    mock_save_responses,
+    mock_save_event_data,
+    mock_update_message,
+    mock_fetch_thread,
+    mock_get_responses,
+):
+    event = make_interest_event(open_=False)
+    mock_set_status.return_value = event
+    mock_get_responses.return_value = [make_response(1, "alice", extra_people=1)]
+    mock_thread = MagicMock(spec=discord.Thread)
+    mock_thread.send = AsyncMock()
+    mock_fetch_thread.return_value = mock_thread
+    close_msg = "x" * 3000
+
+    await perform_close_event(MagicMock(spec=discord.Client), event.event_name, close_msg)
+
+    sent = mock_thread.send.call_args[0][0]
+    tally = build_interest_check_tally(event)
+    assert len(sent) <= 2000
+    assert sent.startswith(tally)
+    assert sent == f"{tally}\n\n{close_msg[: 2000 - len(tally) - 2]}"
 
 
 @patch("offkai_bot.event_actions.fetch_thread_for_event", new_callable=AsyncMock)

--- a/frontend/app/api/attendee/route.ts
+++ b/frontend/app/api/attendee/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server'
-import { readEvents, readResponses, readCheckins, getDefaultEvent } from '../db'
+import { readEvents, readResponses, readCheckins, getDefaultEvent, isSelectableForCheckin } from '../db'
 import { verifyToken } from '../token'
 import { MOCK_EVENTS, MOCK_ATTENDEES, mockCheckins, findMockAttendee } from '../mock'
 
@@ -19,12 +19,12 @@ export async function GET(request: NextRequest) {
     // Event is the one the (v2) token is bound to, else the same default the
     // admin dashboard uses — never a divergent "active event" guess.
     const eventName = resolved.eventName || getDefaultEvent(MOCK_EVENTS)?.event_name
-    if (!eventName || !MOCK_ATTENDEES[eventName]) {
+    const ev = MOCK_EVENTS.find(e => e.event_name === eventName)
+    if (!eventName || !ev || !isSelectableForCheckin(ev) || !MOCK_ATTENDEES[eventName]) {
       return NextResponse.json({ error: 'not_found' }, { status: 404 })
     }
     const mockA = findMockAttendee(eventName, resolved.userId)
     if (!mockA) return NextResponse.json({ error: 'not_found' }, { status: 404 })
-    const ev = MOCK_EVENTS.find(e => e.event_name === eventName)!
     const isCheckedIn = mockCheckins.some(c => c.user_id === mockA.user_id && c.event_name === eventName)
     return NextResponse.json({
       attendee: {
@@ -48,11 +48,13 @@ export async function GET(request: NextRequest) {
   // Resolve the attendee's event: bound by the token (v2) or the shared default.
   let event
   if (resolved.eventName) {
-    event = events.find(e => e.event_name === resolved.eventName && !e.archived)
+    event = events.find(e => e.event_name === resolved.eventName)
   } else {
     event = getDefaultEvent(events)
   }
-  if (!event) return NextResponse.json({ error: 'not_found' }, { status: 404 })
+  if (!event || !isSelectableForCheckin(event)) {
+    return NextResponse.json({ error: 'not_found' }, { status: 404 })
+  }
 
   const responses = readResponses()
   const eventResponses = responses[event.event_name]

--- a/frontend/app/api/attendees/route.ts
+++ b/frontend/app/api/attendees/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server'
-import { readEvents, readResponses, getDefaultEvent } from '../db'
+import { readEvents, readResponses, getDefaultEvent, isSelectableForCheckin } from '../db'
 import { parseEventParam } from '../validation'
 import { MOCK_EVENTS, MOCK_ATTENDEES } from '../mock'
 
@@ -18,11 +18,14 @@ export async function GET(request: NextRequest) {
   }
 
   if (MOCK_MODE) {
-    const defaultEvent = getDefaultEvent(MOCK_EVENTS)
-    const eventName = requestedEvent || defaultEvent?.event_name
-    if (!eventName) {
+    const activeEvent = requestedEvent
+      ? MOCK_EVENTS.find(e => e.event_name === requestedEvent && isSelectableForCheckin(e))
+      : getDefaultEvent(MOCK_EVENTS)
+    if (!activeEvent) {
+      if (requestedEvent) return NextResponse.json({ error: 'event_not_found' }, { status: 404 })
       return NextResponse.json({ event_name: 'No Active Event', attendees: [] })
     }
+    const eventName = activeEvent.event_name
     if (!MOCK_ATTENDEES[eventName]) {
       return NextResponse.json({ error: 'event_not_found' }, { status: 404 })
     }
@@ -34,7 +37,7 @@ export async function GET(request: NextRequest) {
   // Resolve which event to show: an explicit (validated) selection, else default.
   let activeEvent
   if (requestedEvent) {
-    activeEvent = events.find(e => e.event_name === requestedEvent && !e.archived)
+    activeEvent = events.find(e => e.event_name === requestedEvent && isSelectableForCheckin(e))
     if (!activeEvent) {
       return NextResponse.json({ error: 'event_not_found' }, { status: 404 })
     }

--- a/frontend/app/api/checkin/route.ts
+++ b/frontend/app/api/checkin/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server'
-import { readEvents, readResponses, readCheckins, writeCheckins, getDefaultEvent } from '../db'
+import { readEvents, readResponses, readCheckins, writeCheckins, getDefaultEvent, isSelectableForCheckin } from '../db'
 import type { CheckinRecord } from '../db'
 import { verifyToken } from '../token'
 import { parseEventParam, parseUserId } from '../validation'
@@ -42,6 +42,7 @@ function resolveAttendee(eventName: string, userId: string):
     const ev = MOCK_EVENTS.find(e => e.event_name === eventName)
     if (!ev || !MOCK_ATTENDEES[eventName]) return { ok: false, kind: 'event_not_found' }
     if (ev.archived) return { ok: false, kind: 'event_archived' }
+    if (!isSelectableForCheckin(ev)) return { ok: false, kind: 'event_not_found' }
     const a = findMockAttendee(eventName, userId)
     if (!a || a.status !== 'attending') return { ok: false, kind: 'attendee_not_in_event' }
     return { ok: true, user_id: a.user_id, name: a.display_name || a.username }
@@ -50,6 +51,7 @@ function resolveAttendee(eventName: string, userId: string):
   const ev = readEvents().find(e => e.event_name === eventName)
   if (!ev) return { ok: false, kind: 'event_not_found' }
   if (ev.archived) return { ok: false, kind: 'event_archived' }
+  if (!isSelectableForCheckin(ev)) return { ok: false, kind: 'event_not_found' }
   const er = readResponses()[eventName]
   const a = (er?.attendees || []).find(x => x.user_id === userId)
   if (!a) return { ok: false, kind: 'attendee_not_in_event' }
@@ -121,6 +123,11 @@ function defaultEventName(): string | null {
   return getDefaultEvent(src)?.event_name ?? null
 }
 
+function isAvailableCheckinEvent(eventName: string): boolean {
+  const events = MOCK_MODE ? MOCK_EVENTS : readEvents()
+  return events.some(e => e.event_name === eventName && isSelectableForCheckin(e))
+}
+
 // Shared check-out entry point used by both POST(action=checkout) and DELETE.
 function performCheckout(rawUserId: unknown, rawBodyEvent: unknown, rawQueryEvent: string | null) {
   const userId = parseUserId(rawUserId)
@@ -159,6 +166,9 @@ export async function GET(request: NextRequest) {
   }
   const eventName = requestedEvent || defaultEventName()
   if (!eventName) return NextResponse.json([])
+  if (!isAvailableCheckinEvent(eventName)) {
+    return NextResponse.json({ error: 'event_not_found' }, { status: 404 })
+  }
 
   const checkins = MOCK_MODE ? mockCheckins : readCheckins()
   return NextResponse.json(checkins.filter(c => c.event_name === eventName))

--- a/frontend/app/api/db.ts
+++ b/frontend/app/api/db.ts
@@ -146,8 +146,9 @@ export interface EventLike {
   interest_check?: boolean
 }
 
-// Interest checks have no attendance to check in — keep them out of the admin UI.
-function isSelectable(e: EventLike): boolean {
+// Interest checks have no attendance to check in — keep them out of every
+// admin/check-in route, including direct API requests.
+export function isSelectableForCheckin(e: EventLike): boolean {
   return !e.archived && !e.interest_check
 }
 
@@ -156,11 +157,10 @@ function isSelectable(e: EventLike): boolean {
 //    or later — so an event still counts as the default on the day it happens)
 //  - if every event is in the past, the most recent past one
 export function getDefaultEvent<T extends EventLike>(events: T[]): T | null {
-  const dated = events.filter(e => isSelectable(e) && e.event_datetime)
+  const dated = events.filter(e => isSelectableForCheckin(e) && e.event_datetime)
   if (dated.length === 0) {
-    const nonArchived = events.filter(isSelectable)
-    if (nonArchived.length > 0) return nonArchived[nonArchived.length - 1]
-    return events.length > 0 ? events[events.length - 1] : null
+    const selectable = events.filter(isSelectableForCheckin)
+    return selectable.length > 0 ? selectable[selectable.length - 1] : null
   }
 
   const todayKey = jstDayNumber(new Date())
@@ -186,7 +186,7 @@ export function orderEventsForDropdown<T extends EventLike>(events: T[]): T[] {
   const isUpcoming = (e: T) =>
     e.event_datetime ? jstDayNumber(new Date(e.event_datetime)) >= todayKey : false
 
-  const selectable = events.filter(isSelectable)
+  const selectable = events.filter(isSelectableForCheckin)
   const upcoming = selectable.filter(isUpcoming).sort((a, b) => time(a) - time(b))
   const past = selectable.filter(e => !isUpcoming(e)).sort((a, b) => time(b) - time(a))
   return [...upcoming, ...past]

--- a/frontend/app/api/db.ts
+++ b/frontend/app/api/db.ts
@@ -12,6 +12,8 @@ export interface Event {
   archived: boolean
   drinks: string[]
   max_capacity: number | null
+  // Non-binding interest gauges; excluded from the check-in admin UI.
+  interest_check?: boolean
 }
 
 export interface BotAttendee {
@@ -141,6 +143,12 @@ export interface EventLike {
   event_name: string
   event_datetime: string | null
   archived: boolean
+  interest_check?: boolean
+}
+
+// Interest checks have no attendance to check in — keep them out of the admin UI.
+function isSelectable(e: EventLike): boolean {
+  return !e.archived && !e.interest_check
 }
 
 // Default event for the admin dropdown (issue #77):
@@ -148,9 +156,9 @@ export interface EventLike {
 //    or later — so an event still counts as the default on the day it happens)
 //  - if every event is in the past, the most recent past one
 export function getDefaultEvent<T extends EventLike>(events: T[]): T | null {
-  const dated = events.filter(e => !e.archived && e.event_datetime)
+  const dated = events.filter(e => isSelectable(e) && e.event_datetime)
   if (dated.length === 0) {
-    const nonArchived = events.filter(e => !e.archived)
+    const nonArchived = events.filter(isSelectable)
     if (nonArchived.length > 0) return nonArchived[nonArchived.length - 1]
     return events.length > 0 ? events[events.length - 1] : null
   }
@@ -178,9 +186,8 @@ export function orderEventsForDropdown<T extends EventLike>(events: T[]): T[] {
   const isUpcoming = (e: T) =>
     e.event_datetime ? jstDayNumber(new Date(e.event_datetime)) >= todayKey : false
 
-  const selectable = events.filter(e => !e.archived)
+  const selectable = events.filter(isSelectable)
   const upcoming = selectable.filter(isUpcoming).sort((a, b) => time(a) - time(b))
   const past = selectable.filter(e => !isUpcoming(e)).sort((a, b) => time(b) - time(a))
   return [...upcoming, ...past]
 }
-

--- a/frontend/app/api/interest-checks.test.ts
+++ b/frontend/app/api/interest-checks.test.ts
@@ -1,0 +1,34 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+// Node's native TypeScript runner requires the explicit extension, while the
+// application tsconfig intentionally disallows it for production imports.
+// @ts-expect-error TS5097: this specifier is only used by the Node test runner.
+import { getDefaultEvent, isSelectableForCheckin } from './db.ts'
+
+// The frontend previously had no test runner. Node can execute this small API
+// regression suite directly while stripping TypeScript syntax, without adding
+// a test framework just for route coverage. The API routes use this helper for
+// their default and direct event-selection guards.
+
+const interestEvent = {
+  event_name: 'Possible Karaoke Night',
+  venue: null,
+  address: null,
+  google_maps_link: null,
+  event_datetime: null,
+  event_deadline: null,
+  open: true,
+  archived: false,
+  drinks: [],
+  max_capacity: null,
+  interest_check: true,
+}
+
+test('interest checks never become the default check-in event', () => {
+  assert.equal(getDefaultEvent([interestEvent]), null)
+})
+
+test('interest checks are never selectable for direct check-in or attendee-token API requests', () => {
+  assert.equal(isSelectableForCheckin(interestEvent), false)
+  assert.equal(isSelectableForCheckin({ ...interestEvent, interest_check: false }), true)
+})

--- a/frontend/app/api/mock.ts
+++ b/frontend/app/api/mock.ts
@@ -12,6 +12,7 @@ export interface MockEvent {
   event_deadline: string
   open: boolean
   archived: boolean
+  interest_check?: boolean
   drinks: string[]
   max_capacity: number | null
 }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "eslint"
+    "lint": "eslint",
+    "test": "node --experimental-strip-types --test app/api/interest-checks.test.ts"
   },
   "dependencies": {
     "html5-qrcode": "^2.3.8",


### PR DESCRIPTION
# Summary

Adds a lightweight **interest check** mode for gauging a rough headcount before committing to a venue, as an alternative to the full binding signup flow. Interest checks are ordinary `Event`s with a new `interest_check: bool = False` flag, so they reuse the existing persistence, thread, message-update, `/attendance`, and auto-close infrastructure.

## New command

`/create_interest_check <event_name> <date_time> [deadline] [announce_msg]` — creates a thread with an announcement showing a live **"🙋 Interested so far: N"** count and an "I'm interested" button. Venue/address/maps are stored as placeholders and omitted from the message; the date is labeled *Tentative*.

## User flow

- Clicking **"🙋 I'm interested"** opens a one-field modal: extra people you'd bring (0–5). No behave/arrival confirmations, no drinks, no extras names, and the announcement skips the `OFFKAI_MESSAGE` rules entirely — the message explicitly says it's not a signup.
- Registrations are stored as normal `Response` objects (`behavior_confirmed=False`, `arrival_confirmed=False`), so counting and `/attendance` work unchanged.
- **Withdraw interest** carries none of the payment/moderation warnings; confirmations are ephemeral-only (no DMs).
- The live count refreshes on register, withdraw, and organizer `/delete_response`.

## Non-binding semantics

Interest responses deliberately skip: rank/milestone updates, event roles, check-in QR reminders, the 7d/3d/24h deadline countdown pings (only the auto-close task is scheduled), and the waitlist/capacity machinery.

## Closing

At the deadline the check auto-closes and posts a bilingual tally (total + names with `(+N)` group sizes) to the thread; manual `/close_offkai` posts the same tally.

## Guards

`/promote`, `/waitlist`, `/drinks`, and drinks/capacity changes via `/modify_offkai` raise a new `InterestCheckOperationError` for interest checks. `/delete_response` skips the rank decrement and waitlist promotion.

## Frontend

`interest_check` added to the `Event` interface; interest checks are excluded from the admin check-in dropdown and default-event selection (`isSelectable` in `db.ts`).

## Compatibility

- Old `events.json` entries load with `interest_check=False` (covered by test).
- Interest views are wired through `get_event_view`, so buttons survive restarts via the existing startup re-attach path.
- New button/modal `custom_id`s (`interest_button`, `interest_withdraw_button`, `interest_closed_button`, `imodal_` prefix) don't collide with existing ones; the `imodal_` prefix keeps max-length event names within Discord's 100-char `custom_id` cap.

## Test plan

- [x] `uvx ruff check` / `uvx ruff format` clean
- [x] `uvx ty check` clean
- [x] `uv run pytest bot/tests` — 678 passed (36 new tests: loader defaults, modal validation/submit/duplicate, withdraw, view dispatch in all three states, live-count template, close tally, reminder registration, command guards)
- [x] `npm run lint --prefix frontend` and `npm run build --prefix frontend` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)